### PR TITLE
[feat/OPS-134] ApiV1Controller 작성 완료.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ local.properties
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.idea/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/controller/ApiV1MemberController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/controller/ApiV1MemberController.java
@@ -1,0 +1,81 @@
+package org.tuna.zoopzoop.backend.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.tuna.zoopzoop.backend.domain.member.dto.req.ReqBodyForEditMemberName;
+import org.tuna.zoopzoop.backend.domain.member.dto.res.ResBodyForEditMemberName;
+import org.tuna.zoopzoop.backend.domain.member.dto.res.ResBodyForGetMemberInfo;
+import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+import org.tuna.zoopzoop.backend.domain.member.service.MemberService;
+import org.tuna.zoopzoop.backend.global.rsData.RsData;
+import org.tuna.zoopzoop.backend.global.security.jwt.CustomUserDetails;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/member")
+@Tag(name = "ApiV1MemberController", description = "사용자 REST API 컨트롤러")
+public class ApiV1MemberController {
+    private final MemberService memberService;
+    /// api/v1/member/me : 사용자 정보 조회 (GET)
+    /// api/v1/member/edit : 사용자 닉네임 수정 (PUT)
+    /// api/v1/member : 사용자 탈퇴 (DELETE)
+    @GetMapping("/me")
+    @Operation(summary = "사용자 정보 조회")
+    public ResponseEntity<RsData<ResBodyForGetMemberInfo>> getMemberInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Member member = userDetails.getMember();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(
+                        new RsData<>(
+                                "200",
+                                "사용자 정보를 조회했습니다.",
+                                new ResBodyForGetMemberInfo(member)
+                        )
+                );
+    }
+
+    @PutMapping("/edit")
+    @Operation(summary = "사용자 닉네임 수정")
+    public ResponseEntity<RsData<ResBodyForEditMemberName>> editMemberName(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ReqBodyForEditMemberName reqBodyForEditMemberName
+            ) {
+        Member member = userDetails.getMember();
+        member.updateName(reqBodyForEditMemberName.newName());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(
+                        new RsData<>(
+                                "200",
+                                "사용자의 닉네임을 변경했습니다.",
+                                new ResBodyForEditMemberName(member.getName())
+                        )
+                );
+    }
+
+    @DeleteMapping
+    @Operation(summary = "사용자 삭제")
+    public ResponseEntity<RsData<Void>> deleteMember(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Member member = userDetails.getMember();
+        memberService.hardDeleteMember(member);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(
+                        new RsData<>(
+                                "200",
+                                "정상적으로 탈퇴되었습니다.",
+                                null
+                        )
+                );
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/dto/req/ReqBodyForEditMemberName.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/dto/req/ReqBodyForEditMemberName.java
@@ -1,0 +1,12 @@
+package org.tuna.zoopzoop.backend.domain.member.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReqBodyForEditMemberName(
+        @NotBlank(message = "잘못된 요청입니다.") //MethodArgumentException
+        String newName
+) {
+    public ReqBodyForEditMemberName(String newName){
+        this.newName = newName;
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/dto/res/ResBodyForEditMemberName.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/dto/res/ResBodyForEditMemberName.java
@@ -1,0 +1,9 @@
+package org.tuna.zoopzoop.backend.domain.member.dto.res;
+
+public record ResBodyForEditMemberName(
+        String name
+) {
+    public ResBodyForEditMemberName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/dto/res/ResBodyForGetMemberInfo.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/dto/res/ResBodyForGetMemberInfo.java
@@ -1,0 +1,19 @@
+package org.tuna.zoopzoop.backend.domain.member.dto.res;
+
+import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+
+public record ResBodyForGetMemberInfo(
+        Integer id,
+        String name,
+        String email,
+        String profileUrl
+) {
+    public ResBodyForGetMemberInfo(Member member){
+        this(
+                member.getId(),
+                member.getName(),
+                member.getEmail(),
+                member.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/service/MemberService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.domain.member.repository.MemberRepository;
 
@@ -36,6 +37,7 @@ public class MemberService {
     //빈 List를 전달하는 경우, 예외 처리를 할 지는 고민해봐야 할 사항.
 
     //회원 생성/정보 수정 관련
+    @Transactional
     public Member createMember(String name, String email, String profileUrl){
         if(memberRepository.findByEmail(email).isPresent()){
             throw new DataIntegrityViolationException("이미 사용중인 이메일입니다.");
@@ -51,6 +53,8 @@ public class MemberService {
                 .build();
         return memberRepository.save(member);
     }
+
+    @Transactional
     public void updateMemberName(Member member, String newName){
         if(memberRepository.findByName(newName).isPresent()) {
             throw new DataIntegrityViolationException("이미 사용중인 이름입니다.");

--- a/src/main/java/org/tuna/zoopzoop/backend/global/config/jwt/JwtProperties.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/config/jwt/JwtProperties.java
@@ -1,0 +1,22 @@
+package org.tuna.zoopzoop.backend.global.config.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtProperties {
+    //application.yml에 jwt 항목 작성
+    //예시
+    //jwt:
+    //  secret-key: mySecretKeyForJWTTokenGenerationAndValidation1234567890
+    //  access-token-validity: 86400000
+    //  refresh-token-validity: 604800000
+    private String secretKey;
+    private long accessTokenValidity;
+    private long refreshTokenValidity;
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/exception/GlobalExceptionHandler.java
@@ -52,15 +52,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class) // 유효하지 않은 메소드 파라미터 예외
     public ResponseEntity<RsData<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         String message = e.getBindingResult()
-                .getAllErrors()
+                .getFieldErrors()
                 .stream()
-                .filter(error -> error instanceof FieldError)
-                .map(error -> {
-                    FieldError fe = (FieldError) error;
-                    return fe.getField() + "-" + fe.getCode() + "-" + fe.getDefaultMessage();
-                })
-                .sorted()
-                .collect(Collectors.joining("\n"));
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("잘못된 요청입니다."); // 메세지가 없을 경우 기본값
 
         return new ResponseEntity<>(
                 new RsData<>(

--- a/src/main/java/org/tuna/zoopzoop/backend/global/rsData/RsData.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/rsData/RsData.java
@@ -1,9 +1,10 @@
 package org.tuna.zoopzoop.backend.global.rsData;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record RsData<T>(
-        String resultCode,
+        @JsonProperty("status") String resultCode,
         @JsonIgnore
         int statusCode,
         String msg,

--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/SecurityConfig.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/SecurityConfig.java
@@ -3,19 +3,21 @@ package org.tuna.zoopzoop.backend.global.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.tuna.zoopzoop.backend.global.security.jwt.CustomAuthenticationEntryPoint;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 // 모든 요청 허용
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/member", "/api/v1/member/**").authenticated()
                         .requestMatchers(
                                 "/",
                                 "/favicon.ico",
@@ -38,8 +40,10 @@ public class SecurityConfig {
 
                 // 기본 인증 비활성화
                 .httpBasic(httpBasic -> httpBasic.disable())
-                .formLogin(formLogin -> formLogin.disable());
-
+                .formLogin(formLogin -> formLogin.disable())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                );
         return http.build();
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package org.tuna.zoopzoop.backend.global.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.tuna.zoopzoop.backend.global.rsData.RsData;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+
+        RsData<Void> body = new RsData<>("401", "액세스가 거부되었습니다.", null);
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/CustomUserDetails.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/CustomUserDetails.java
@@ -1,0 +1,46 @@
+package org.tuna.zoopzoop.backend.global.security.jwt;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+    private final Member member;
+    public CustomUserDetails(Member member) { this.member = member; }
+
+    public Member getMember() { return member; }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() { return null; }
+
+    @Override
+    public String getPassword() { return null; }
+
+    @Override
+    public String getUsername() { return member.getEmail(); }
+
+    public String getNickname() { return member.getName(); }
+    public String getProfileImageUrl() { return member.getProfileImageUrl(); }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // 계정 만료 여부
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // 계정 잠금 여부
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return member.isActive(); // 계정 활성화 여부
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,68 @@
+package org.tuna.zoopzoop.backend.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.tuna.zoopzoop.backend.global.security.service.CustomUserDetailsService;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = getTokenFromRequest(request); // Authorization 헤더에서 JWT 토큰 추출
+
+        if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) { // 토큰이 존재하고 유효한 경우
+            String email = jwtUtil.getEmailFromToken(token); //토큰에서 이메일 추출
+
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email); // 사용자 정보 로드
+
+            //권한 생성 로직 X (사용 안함.)
+
+            UsernamePasswordAuthenticationToken authentication = // Spring Security 인증 객체 생성
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            null
+                    );
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication); // SecurityContext에 인증 정보 설정
+        }
+        filterChain.doFilter(request, response); // 다음 필터로 요청 전달
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) { // Authorization 헤더에서 Bearer 토큰 추출
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7); // "Bearer " 제거
+        }
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/JwtUtil.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/JwtUtil.java
@@ -1,0 +1,129 @@
+package org.tuna.zoopzoop.backend.global.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+import org.tuna.zoopzoop.backend.global.config.jwt.JwtProperties;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtUtil {
+    private final JwtProperties jwtProperties;
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+    }
+
+    // JWT 토큰 생성
+    public String generateToken(Member member) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtProperties.getAccessTokenValidity());
+
+        return Jwts.builder()
+                .setSubject(member.getEmail())
+                .claim("userId", member.getId())
+                .claim("name", member.getName())
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // 토큰에서 이메일 추출
+    public String getEmailFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getSubject();
+    }
+
+    // 토큰에서 이름 추출
+    public String getNameFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.get("name").toString();
+    }
+
+    // 토큰에서 사용자 ID 추출
+    public int getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.get("userId", Integer.class);
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.error("JWT 토큰이 만료되었습니다: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.error("잘못된 JWT 토큰입니다: {}", e.getMessage());
+        } catch (SecurityException e) {
+            log.error("JWT 서명이 잘못되었습니다: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 비어있습니다: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    // 리프레시 토큰 생성
+    public String generateRefreshToken(Member member) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtProperties.getRefreshTokenValidity());
+
+        return Jwts.builder()
+                .setSubject(member.getEmail())
+                .claim("userId", member.getId())
+                .claim("name", member.getName())
+                .claim("tokenType", "refresh")
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    // 리프레시 토큰 여부 확인
+    public boolean isRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(getSigningKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return "refresh".equals(claims.get("tokenType"));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // 토큰의 만료 날짜 추출
+    public Date getExpirationDateFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getExpiration();
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/service/CustomUserDetailsService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/service/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package org.tuna.zoopzoop.backend.global.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+import org.tuna.zoopzoop.backend.domain.member.service.MemberService;
+import org.tuna.zoopzoop.backend.global.security.jwt.CustomUserDetails;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberService memberService;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberService.findByEmail(email);
+        if (!member.isActive()) {
+            throw new UsernameNotFoundException("비활성화된 계정입니다: " + email);
+        }
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,135 @@
+package org.tuna.zoopzoop.backend.domain.member.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.tuna.zoopzoop.backend.domain.member.dto.req.ReqBodyForEditMemberName;
+import org.tuna.zoopzoop.backend.domain.member.repository.MemberRepository;
+import org.tuna.zoopzoop.backend.domain.member.service.MemberService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MemberControllerTest {
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeAll
+    void setUp() {
+        memberService.createMember(
+                "test",
+                "test@test.com",
+                "url");
+        memberService.createMember(
+                "test2",
+                "test2@test.com",
+                "url");
+        memberService.createMember(
+                "test3",
+                "test3@test.com",
+                "url");
+    }
+
+    @Test
+    @WithUserDetails(value = "test@test.com", setupBefore = TestExecutionEvent.TEST_METHOD)
+    @DisplayName("사용자 정보 조회 - 성공(200)")
+    void getMemberInfoSuccess() throws Exception {
+        mockMvc.perform(get("/api/v1/member/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.name").value("test"))
+                .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                .andExpect(jsonPath("$.data.profileUrl").value("url"));
+    }
+
+    @Test
+    @DisplayName("사용자 정보 조회 - 실패(401, Unauthorized)")
+    void getMemberInfoFailed() throws Exception {
+        mockMvc.perform(get("/api/v1/member/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.msg").value("액세스가 거부되었습니다."));
+    }
+
+    @Test
+    @WithUserDetails(value = "test@test.com", setupBefore = TestExecutionEvent.TEST_METHOD)
+    @DisplayName("사용자 이름 수정 - 성공(200)")
+    void editMemberNameSuccess() throws Exception {
+        ReqBodyForEditMemberName reqBodyForEditMemberName = new ReqBodyForEditMemberName("test3");
+        mockMvc.perform(put("/api/v1/member/edit")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(reqBodyForEditMemberName)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("사용자의 닉네임을 변경했습니다."))
+                .andExpect(jsonPath("$.data.name").value("test3"));
+    }
+
+    @Test
+    @WithUserDetails(value = "test@test.com", setupBefore = TestExecutionEvent.TEST_METHOD)
+    @DisplayName("사용자 이름 수정 - 실패(400, Bad_Request)")
+    void editMemberNameFailedByBadRequest() throws Exception {
+        ReqBodyForEditMemberName reqBodyForEditMemberName = new ReqBodyForEditMemberName("");
+        mockMvc.perform(put("/api/v1/member/edit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqBodyForEditMemberName)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.msg").value("잘못된 요청입니다."));
+    }
+
+    @Test
+    @DisplayName("사용자 이름 수정 - 실패(401, Unauthorized)")
+    void editMemberNameFailedByUnauthorized() throws Exception {
+        ReqBodyForEditMemberName reqBodyForEditMemberName = new ReqBodyForEditMemberName("test3");
+        mockMvc.perform(put("/api/v1/member/edit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reqBodyForEditMemberName)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.msg").value("액세스가 거부되었습니다."));
+    }
+
+    @Test
+    @WithUserDetails(value = "test3@test.com", setupBefore = TestExecutionEvent.TEST_METHOD)
+    @DisplayName("사용자 삭제 - 성공(200)")
+    void deleteMemberSuccess() throws Exception {
+        mockMvc.perform(delete("/api/v1/member"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("정상적으로 탈퇴되었습니다."));
+    }
+
+    @Test
+    @DisplayName("사용자 삭제 - 실패(401, Unauthorized)")
+    void deleteMemberFailed() throws Exception {
+        mockMvc.perform(delete("/api/v1/member"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.msg").value("액세스가 거부되었습니다."));
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명

ApiV1Controller 작성 완료.
- /api/v1/member/me (GET) : 사용자 정보 조회
- /api/v1/member/edit (PUT) : 사용자 이름 수정 
- /api/v1/member (DELETE) : 사용자 삭제(탈퇴)

 @AuthenticationPrincipal 사용을 위한 JWT 토큰 관련 설정 완료
- CustomUserDetails
- CustomUserDetailsService
- CustomAuthenticationEntryPoint : AuthenticationException (401,Unauthorized)를 위한 클래스
- JwtUtils
- JwtAuthenticationFilter
- JwtProperties : application.yml에 작성된 jwt 관련 정보 추출(추후에 작성 해야 함.)

정상적으로 오류 메세지를 출력하도록 GlobalExceptionHandler 메소드 일부 수정
- handleMethodArgumentNotValidException
- *비슷한 형태로 handleConstraintViolationException도 수정이 필요해 보이지만, 일단 건들지 않음.

REST API 테스트를 위한 MemberControllerTest 작성

<br>

## 🩷 Approve 하기 전 확인해주세요!

CI 테스트 결과 확인 바랍니다.


<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

