### PR TITLE
[fix/OPS-271] SecurityConfig 및 Jwt 인증 필터 수정

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/SecurityConfig.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/SecurityConfig.java
@@ -5,12 +5,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.tuna.zoopzoop.backend.global.security.jwt.CustomAuthenticationEntryPoint;
+import org.tuna.zoopzoop.backend.global.security.jwt.JwtAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -44,7 +47,8 @@ public class SecurityConfig {
                 .formLogin(formLogin -> formLogin.disable())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);;
         return http.build();
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -30,11 +30,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         String token = getTokenFromRequest(request); // Authorization 헤더에서 JWT 토큰 추출
+        log.info("[JwtFilter] Token from request: {}", token);
+        log.info("[JwtFilter] Token valid? {}", jwtUtil.validateToken(token));
 
         if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) { // 토큰이 존재하고 유효한 경우
             String kakaoKey = jwtUtil.getKakaoKeyFromToken(token); //토큰에서 카카오 키 값 추출
+            log.info("[JwtFilter] KakaoKey from token: {}", kakaoKey);
 
             UserDetails userDetails = userDetailsService.loadUserByUsername(kakaoKey); // 사용자 정보 로드
+            log.info("[JwtFilter] UserDetails loaded: {}", userDetails);
 
             //권한 생성 로직 X (사용 안함.)
 


### PR DESCRIPTION
## 📢 기능 설명

@AuthenticationPrincipal 어노테이션을 통해 CustomUserDetails를 정상적으로 불러올 수 있도록, SecurityConfig에 JwtAuthenticationFilter를 등록했습니다.

## 🩷 Approve 하기 전 확인해주세요!

- [ ] merge 이후, @AuthenticationPrincipal 어노테이션을 사용하는 API를 테스트 가능할 경우 해보시길 바랍니다.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

