### PR TITLE
Hotfix global exception handler 컨벤션 통일

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/exception/GlobalExceptionHandler.java
@@ -54,9 +54,15 @@ public class GlobalExceptionHandler {
         String message = e.getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .findFirst()
-                .map(FieldError::getDefaultMessage)
-                .orElse("잘못된 요청입니다."); // 메세지가 없을 경우 기본값
+                .map(error ->
+                        // {필드명}-{에러코드}-{기본메시지} 형식으로 조합
+                        String.format("%s-%s-%s",
+                                error.getField(),
+                                error.getCode(),
+                                error.getDefaultMessage())
+                )
+                .sorted() // 여러 에러가 있을 경우를 대비해 정렬
+                .collect(Collectors.joining("\n")); // 여러 에러를 줄바꿈으로 연결
 
         return new ResponseEntity<>(
                 new RsData<>(

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
@@ -98,7 +98,7 @@ public class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(reqBodyForEditMemberName)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.msg").value("잘못된 요청입니다."));
+                .andExpect(jsonPath("$.msg").value("newName-NotBlank-잘못된 요청입니다."));
     }
 
     @Test


### PR DESCRIPTION
## 📢 기능 설명
```
@ExceptionHandler(MethodArgumentNotValidException.class) // 유효하지 않은 메소드 파라미터 예외
    public ResponseEntity<RsData<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
        String message = e.getBindingResult()
                .getFieldErrors()
                .stream()
                .map(error ->
                        // {필드명}-{에러코드}-{기본메시지} 형식으로 조합
                        String.format("%s-%s-%s",
                                error.getField(),
                                error.getCode(),
                                error.getDefaultMessage())
                )
                .sorted() // 여러 에러가 있을 경우를 대비해 정렬
                .collect(Collectors.joining("\n")); // 여러 에러를 줄바꿈으로 연결

        return new ResponseEntity<>(
                new RsData<>(
                        "400",
                        message
                ),
                BAD_REQUEST
        );
    }
```
- validation 에러에 대해 반환하는 message 형식 통일
- 관련된 memberControllerTest 의 단위 테스트 하나 수정 (message 형식만 통일)

<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] 
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
- [x] Approve 하기 전 확인 사항 체크했는가?

