### PR TITLE
Feat/ops 210 be feat 폴더 삭제 

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderController.java
@@ -46,6 +46,20 @@ public class FolderController {
 
     }
 
+    /**
+     * 내 PersonalArchive 안의 folder 삭제
+     * @param folderId  삭제할 folderId
+     */
+    @DeleteMapping("/{folderId}")
+    public ResponseEntity<Map<String, Object>> deleteFolder(@PathVariable Integer folderId) {
+        String deletedFolderName = folderService.deleteFolder(folderId);
 
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", 200);
+        body.put("msg", deletedFolderName + " 폴더가 삭제됐습니다.");
+        body.put("data", null);
+
+        return ResponseEntity.ok(body);
+    }
 
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
@@ -110,6 +110,19 @@ public class FolderService {
         return file + " (" + (used.size() + 1) + ")"; // fallback
     }
 
+    /**
+     *  folderId에 해당하는 폴더 삭제
+     *  soft delete 아직 구현 X
+     */
+    @Transactional
+    public String deleteFolder(Integer folderId) {
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new NoResultException("존재하지 않는 폴더입니다."));
+
+        String name = folder.getName();
+        folderRepository.delete(folder);
+        return name;
+    }
 
     /**
      * 입력된 폴더명을 (폴더명, 숫자)로 분리하는 유틸 클래스

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
@@ -75,5 +75,31 @@ class FolderControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    // DeleteFile
+    @Test
+    @DisplayName("개인 아카이브 폴더 삭제 - 성공 시 200과 삭제 메시지 반환")
+    void deleteFolder_ok() throws Exception {
+        // given
+        when(folderService.deleteFolder(7)).thenReturn("보고서");
 
+        // when & then
+        mockMvc.perform(delete("/api/v1/archive/folder/{folderId}", 7))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("보고서 폴더가 삭제됐습니다."));
+    }
+
+    @Test
+    @DisplayName("개인 아카이브 폴더 삭제 - 존재하지 않으면 404")
+    void deleteFolder_notFound() throws Exception {
+        // given
+        when(folderService.deleteFolder(404))
+                .thenThrow(new NoResultException("존재하지 않는 폴더입니다."));
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/archive/folder/{folderId}", 404))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("404"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 폴더입니다."));
+    }
 }

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
@@ -104,4 +104,30 @@ class FolderServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> folderService.createFolderForPersonal(2, "보고서"));
     }
+
+    // ---------- Delete ----------
+    @Test
+    @DisplayName("폴더 삭제 성공")
+    void deleteFolder_success() {
+        Folder folder = new Folder();
+        folder.setName("보고서");
+        folder.setArchive(archive);
+        ReflectionTestUtils.setField(folder, "id", 500);
+
+        when(folderRepository.findById(500)).thenReturn(Optional.of(folder));
+
+        String deletedName = folderService.deleteFolder(500);
+
+        assertThat(deletedName).isEqualTo("보고서");
+        verify(folderRepository, times(1)).delete(folder);
+    }
+
+    @Test
+    @DisplayName("폴더 삭제 실패 - 존재하지 않는 폴더")
+    void deleteFolder_notFound() {
+        when(folderRepository.findById(999)).thenReturn(Optional.empty());
+
+        assertThrows(NoResultException.class, () -> folderService.deleteFolder(999));
+        verify(folderRepository, never()).delete(any(Folder.class));
+    }
 }


### PR DESCRIPTION
## 📢 기능 설명
<br>
폴더 삭제 API 추가
- 특정 folderId를 전달받아 해당 폴더를 삭제할 수 있는 엔드포인트 구현

예외 처리
- 존재하지 않는 폴더 요청 시 NotFound 예외 반환
- 삭제 권한이 없을 경우 적절한 에러 응답 처리

엔티티/서비스 계층 보완
- FolderService에 삭제 로직 추가
- Controller → Service 연동

테스트 코드 작성
- 정상 삭제 시 200 응답 확인
- 존재하지 않는 폴더 삭제 요청 시 예외 검증

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

