### PR TITLE
[feat/OPS-195] 뉴스 목록 조회 기능 구현(최신 뉴스, 키워드 기반). 서비스 테스트 추가.

### DIFF
--- a/backend.iml
+++ b/backend.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="backend" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="org.tuna.zoopzoop" external.system.module.version="0.0.1-SNAPSHOT" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/auth/controller/ApiV1AuthController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/auth/controller/ApiV1AuthController.java
@@ -1,5 +1,6 @@
 package org.tuna.zoopzoop.backend.domain.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class ApiV1AuthController {
     private final JwtProperties jwtProperties;
 
     @GetMapping("/logout")
+    @Operation(summary = "사용자 로그아웃")
     public ResponseEntity<RsData<Void>> logout(HttpServletResponse response) {
         ResponseCookie accessCookie = ResponseCookie.from("accessToken", "")
                 .httpOnly(true)
@@ -53,6 +55,7 @@ public class ApiV1AuthController {
     }
 
     @PostMapping("/refresh")
+    @Operation(summary = "사용자 액세스 토큰 재발급 (리프레시 토큰이 유효할 경우)")
     public ResponseEntity<RsData<Void>> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken,
                                                          HttpServletResponse response) {
 

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/home/controller/HomeController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/home/controller/HomeController.java
@@ -2,9 +2,14 @@ package org.tuna.zoopzoop.backend.domain.home.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.tuna.zoopzoop.backend.domain.news.service.NewsSearchService;
+import reactor.core.publisher.Mono;
 
 import java.net.InetAddress;
 
@@ -12,6 +17,7 @@ import static java.net.InetAddress.getLocalHost;
 import static org.springframework.util.MimeTypeUtils.TEXT_HTML_VALUE;
 
 @RestController
+@RequiredArgsConstructor
 @Tag(name = "HomeController", description = "홈 컨트롤러")
 public class HomeController {
 //    @Value("${kakao.client_id}")
@@ -19,6 +25,7 @@ public class HomeController {
 //
 //    @Value("${kakao.redirect_uri}")
 //    private String kakaoRedirectUri;
+    private final NewsSearchService newsSearchService;
 
     @SneakyThrows
     @GetMapping(produces = TEXT_HTML_VALUE)
@@ -46,6 +53,22 @@ public class HomeController {
                 <div>
                     <a href="%s">로그아웃 테스트</a>
                 </div>
+                
+                <h2>뉴스 검색 테스트</h2>
+                <form action="/search-news" method="get">
+                    <input type="text" name="query" placeholder="검색어 입력"/>
+                    <input type="submit" value="검색"/>
+                </form>
                 """.formatted(localHost.getHostName(), localHost.getHostAddress(), kakaoLoginUrl, googleLoginUrl, logoutUrl);
+    }
+
+    @GetMapping(value = "/search-news", produces = MediaType.TEXT_HTML_VALUE)
+    public Mono<String> searchNews(@RequestParam String query) {
+        return newsSearchService.searchNews(query, 5, 1, "sim")
+                .map("""
+                        <h1>검색 결과</h1>
+                        <pre>%s</pre>
+                        <a href="/">뒤로가기</a>
+                        """::formatted);
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/entity/Member.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/entity/Member.java
@@ -21,9 +21,6 @@ public class Member extends BaseEntity {
     @Column(unique = true, nullable = false)
     private String name;
 
-//    @Column(unique = true, nullable = false)
-//    private String email;
-
     @Column(unique = true, nullable = false)
     private String providerKey;
 

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/controller/ApiV1NewsController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/controller/ApiV1NewsController.java
@@ -1,0 +1,56 @@
+package org.tuna.zoopzoop.backend.domain.news.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.tuna.zoopzoop.backend.domain.news.dto.req.ReqBodyForKeyword;
+import org.tuna.zoopzoop.backend.domain.news.dto.res.ResBodyForNaverNews;
+import org.tuna.zoopzoop.backend.domain.news.service.NewsSearchService;
+import org.tuna.zoopzoop.backend.global.rsData.RsData;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/news")
+@Tag(name = "ApiV1NewsController", description = "뉴스 API 기반 검색 컨트롤러")
+public class ApiV1NewsController {
+    private final NewsSearchService newsSearchService;
+
+    @GetMapping
+    @Operation(summary = "최신 뉴스 목록 조회")
+    public Mono<ResponseEntity<RsData<ResBodyForNaverNews>>> searchRecentNews(
+            @RequestParam(defaultValue = "10") int display
+    ) {
+        return newsSearchService.searchNews("뉴스", display, 1, "date")
+                .map(response -> ResponseEntity
+                        .status(HttpStatus.OK)
+                        .body(new RsData<>(
+                                "200",
+                                "최신 뉴스 목록을 조회했습니다.",
+                                response
+                        )));
+    }
+
+    @PostMapping("/keywords")
+    @Operation(summary = "최신 뉴스 목록 조회")
+    public Mono<ResponseEntity<RsData<ResBodyForNaverNews>>> searchNewsByKeywords(
+            @RequestParam(defaultValue = "10") int display,
+            @RequestBody ReqBodyForKeyword dto
+    ) {
+        String query = String.join(" ", dto.keywords());
+        // AND, OR 연산 쿼리를 지원한다고는 하는데, 정확한지는 모름.
+        // String query = String.join("+", dto.keywords()); // AND 연산 키워드 검색
+        // String query = String.join("|", dto.keywords()); // OR 연산 키워드 검색
+        return newsSearchService.searchNews(query, display, 1, "sim")
+                .map(response -> ResponseEntity
+                        .status(HttpStatus.OK)
+                        .body(new RsData<>(
+                                "200",
+                                "키워드 기반 뉴스 목록을 조회했습니다.",
+                                response
+                        )));
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/dto/req/ReqBodyForKeyword.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/dto/req/ReqBodyForKeyword.java
@@ -1,0 +1,8 @@
+package org.tuna.zoopzoop.backend.domain.news.dto.req;
+
+import java.util.List;
+
+public record ReqBodyForKeyword (
+        List<String> keywords
+) {
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/dto/res/ResBodyForNaverNews.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/dto/res/ResBodyForNaverNews.java
@@ -1,0 +1,30 @@
+package org.tuna.zoopzoop.backend.domain.news.dto.res;
+
+import java.util.List;
+
+public record ResBodyForNaverNews(
+        String lastBuildDate,
+        int total,
+        int start,
+        int display,
+        List<NewsItem> items
+) {
+    public record NewsItem(
+            String title,
+            String link,
+            String description,
+            String pubDate
+    ) {
+        public NewsItem(String title, String link, String description, String pubDate) {
+            this.title = cleanText(title);
+            this.link = link;
+            this.description = cleanText(description);
+            this.pubDate = pubDate;
+        }
+
+        private static String cleanText(String text) {
+            if (text == null) return null;
+            return text.replaceAll("<.*?>", "");
+        }
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/service/NewsSearchService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/service/NewsSearchService.java
@@ -1,0 +1,59 @@
+package org.tuna.zoopzoop.backend.domain.news.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.tuna.zoopzoop.backend.domain.news.dto.res.ResBodyForNaverNews;
+import reactor.core.publisher.Mono;
+
+@Service
+public class NewsSearchService {
+    private final WebClient webClient;
+
+    @Value("${naver.client_id}")
+    private String client_id;
+
+    @Value("${naver.client_secret}")
+    private String client_secret;
+
+    public NewsSearchService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl("https://openapi.naver.com").build();
+    }
+
+    /**
+     * 네이버 뉴스 API
+     * @param query 검색어 (UTF-8로 인코딩 필수)
+     * @param display 한 번에 표시할 결과 수 (기본 값 10, 최대 100)
+     * @param start 검색 시작 위치 (기본값 1, 최대 1000)
+     * @param sort 정렬 방식 ("sim", "date") sim: 정확도 순, date: 날짜 순, 둘다 내림차 순 정렬.
+     */
+
+    /*
+    Q. 어째서 WebClient를 사용하는가?
+    A. WebClient -> 비동기/논블로킹 HTTP 클라이언트.
+    즉, 현재 우리 시스템처럼 여러명의 사용자가 뉴스 API를 통한 검색을 요청할 경우,
+    기존의 Spring MVC, RestTemplate를 사용하면 블로킹된 쓰레드가 바생하여 서버의 리소스를 효율적으로 사용하지 못함.
+
+    추가로, WebFlux의 Mono/Flux의 경우엔 Backpressure를 지원하므로, 데이터가 너무 많이 들어올 경우 서버가 감당 가능하도록 흐름을 조절.
+    *Backpressure(백프레셔) : 수신자가 처리할 수 있는 속도로 발신자가 데이터를 보내도록 하는 것.
+    */
+
+    public Mono<ResBodyForNaverNews> searchNews(String query, Integer display, Integer start, String sort) {
+        int finalDisplay = (display == null) ? 10 : Math.min(display, 100);
+        int finalStart = (start == null) ? 1 : Math.min(start, 1000);
+        String finalSort = (sort == null || (!sort.equals("sim") && !sort.equals("date"))) ? "sim" : sort;
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("v1/search/news.json")
+                        .queryParam("query", query)
+                        .queryParam("display", finalDisplay)
+                        .queryParam("start", finalStart)
+                        .queryParam("sort", finalSort)
+                        .build())
+                .header("X-Naver-Client-Id", client_id)
+                .header("X-Naver-Client-Secret", client_secret)
+                .retrieve()
+                .bodyToMono(ResBodyForNaverNews.class);
+    }
+}

--- a/src/main/resources/application-secrets.yml.template
+++ b/src/main/resources/application-secrets.yml.template
@@ -29,6 +29,10 @@ spring:
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
             user-name-attribute: sub
 
+naver:
+  client_id: {NAVER_CLIENT_ID}
+  client_secret: {NAVER_CLIENT_SECRET}
+
 jwt:
   secret-key: {JWT_SECRET_KEY}
   access-token-validity: {ACCESSTOKEN_VALIDITY}

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/news/service/NewsServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/news/service/NewsServiceTest.java
@@ -1,0 +1,56 @@
+package org.tuna.zoopzoop.backend.domain.news.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.tuna.zoopzoop.backend.domain.news.dto.res.ResBodyForNaverNews;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NewsServiceTest {
+
+    @Test
+    @DisplayName("뉴스 서비스 테스트 - 정상적인 JSON 구조 반환 여부 확인")
+    void newsJsonStructureTest() {
+        // JSON 구조용 더미 데이터
+        ResBodyForNaverNews dummyResponse = new ResBodyForNaverNews(
+                "Mon, 22 Sep 2025 17:35:10 +0900",  // lastBuildDate
+                505376,                                         // total
+                1,                                              // start
+                5,                                              // display
+                List.of(
+                        new ResBodyForNaverNews.NewsItem(       // items
+                                "뉴스 제목",                    // title
+                                "링크",                         // link
+                                "설명",                         // description
+                                "발행일"                        // pubDate
+                        )
+                )
+        );
+
+        Mono<ResBodyForNaverNews> result = Mono.just(dummyResponse);
+
+        // JSON 구조 확인
+        result.doOnNext(res -> {
+            assertNotNull(res.lastBuildDate());
+            assertNotNull(res.total());
+            assertNotNull(res.start());
+            assertNotNull(res.display());
+            assertNotNull(res.items());
+
+            res.items().forEach(item -> {
+                assertNotNull(item.title());
+                assertNotNull(item.link());
+                assertNotNull(item.description());
+                assertNotNull(item.pubDate());
+            });
+        }).block(); // Mono 블로킹.
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명

### 기존 코드 변경 사항
없음

### 추가 사항
네이버 뉴스 API를 사용한 뉴스 검색
- 최신 뉴스 조회(따로 non-keyword 방식의 조회가 없어, 단순히 입력 쿼리를 "뉴스"로 설정하여 검색. 생각보다 잘됨.)
- 키워드 기반 검색(기본 OR 연산인 듯?)

WebFlux 기반의 Mono 타입 값을 return하기 때문에, 기존의 @SpringBootTest 방식을 사용하기 어려워 서비스 테스트만 구현
- *Postman 및 웹으로도 테스트를 완료 했으므로, 크게 작동을 걱정할 필요는 없을 듯 함.
<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] 네이버 뉴스 API를 사용하기 때문에, API KEY 값 등을 적은 application-secrets.yml에 변경 사항이 있습니다. merge 이후 슬랙에 올려드리겠습니다.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

