### PR TITLE
refactor/OPS-277 : default 폴더 자동 생성

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/entity/Archive.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/entity/Archive.java
@@ -28,4 +28,20 @@ public class Archive extends BaseEntity {
     public Archive(ArchiveType archiveType) {
         this.archiveType = archiveType;
     }
+
+    public void addFolder(Folder folder) {
+        if (!this.folders.contains(folder)) {
+            this.folders.add(folder);
+        }
+        if (folder.getArchive() != this) {
+            folder.setArchive(this);
+        }
+    }
+
+    public void removeFolder(Folder folder) {
+        this.folders.remove(folder);
+        if (folder.getArchive() == this) {
+            folder.setArchive(null);
+        }
+    }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/entity/PersonalArchive.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/entity/PersonalArchive.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.tuna.zoopzoop.backend.domain.archive.archive.enums.ArchiveType;
+import org.tuna.zoopzoop.backend.domain.archive.folder.entity.Folder;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.global.jpa.entity.BaseEntity;
 
@@ -38,5 +39,9 @@ public class PersonalArchive extends BaseEntity {
     public PersonalArchive(Member member) {
         this.member = member;
         this.archive = new Archive(ArchiveType.PERSONAL);
+
+        // default 폴더 자동 생성 및 연결
+        Folder defaultFolder = new Folder("default");
+        archive.addFolder(defaultFolder);
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/entity/Folder.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/entity/Folder.java
@@ -45,4 +45,10 @@ public class Folder extends BaseEntity {
     // 폴더 삭제 시 데이터 일괄 삭제
     @OneToMany(mappedBy = "folder", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<DataSource> dataSources = new ArrayList<>();
+
+
+    public Folder(String name) {
+        this.name = name;
+        this.isDefault = true;
+    }
 }

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
@@ -137,6 +137,18 @@ class FolderServiceTest {
         verify(folderRepository, never()).delete(any(Folder.class));
     }
 
+    @Test
+    @DisplayName("default 폴더는 삭제할 수 없다")
+    void deleteFolder_default_forbidden() {
+        Folder defaultFolder = new Folder("default"); // isDefault=true
+        ReflectionTestUtils.setField(defaultFolder, "id", 42);
+
+        when(folderRepository.findById(42)).thenReturn(Optional.of(defaultFolder));
+
+        assertThrows(IllegalArgumentException.class, () -> folderService.deleteFolder(42));
+        verify(folderRepository, never()).delete(any());
+    }
+
     // ---------- Update ----------
     @Test
     @DisplayName("폴더 이름 변경 성공")

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,53 @@
+package org.tuna.zoopzoop.backend.domain.member.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.tuna.zoopzoop.backend.domain.archive.archive.entity.Archive;
+import org.tuna.zoopzoop.backend.domain.archive.folder.entity.Folder;
+import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+public class MemberRepositoryTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+
+    @Test
+    @DisplayName("Member 저장 시 PersonalArchive + Archive + default 폴더가 자동 생성된다")
+    void memberPersistsWithDefaultFolder() {
+        // given: Personal Archive 생성 + Personal Archive 생성자가 Archive와 Default 폴더 생성
+        Member m = Member.builder()
+                .name("alice")
+                .providerKey("kakao-123")
+                .provider(Provider.KAKAO)
+                .profileImageUrl(null)
+                .build();
+
+        // when
+        Member saved = memberRepository.save(m);
+
+        // then
+        var pa = saved.getPersonalArchive();
+        assertThat(pa).isNotNull();
+
+        Archive archive = pa.getArchive();
+        assertThat(archive).isNotNull();
+
+        List<Folder> folders = archive.getFolders();
+        assertThat(folders).isNotEmpty();
+        Folder defaultFolder = folders.stream().filter(Folder::isDefault).findFirst().orElse(null);
+
+        assertThat(defaultFolder).isNotNull();
+        assertThat(defaultFolder.getName()).isEqualTo("default");
+        assertThat(defaultFolder.getArchive()).isSameAs(archive); // 양방향 일관성
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명
<br>
PersonalArchive 생성 시 default 폴더 자동 생성 로직 추가

- Member → PersonalArchive 생성 시, 내부에서 Archive + default Folder가 함께 생성되도록 변경
- 연관관계 편의 메서드 archive.addFolder(defaultFolder)를 통해 일관성 보장
- default 폴더 삭제 생성 및 삭제에 대한 단위 테스트 추가

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

