### PR TITLE
[refactor/OPS-287] News 도메인 고도화

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/auth/controller/ApiV1AuthController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/auth/controller/ApiV1AuthController.java
@@ -24,6 +24,10 @@ public class ApiV1AuthController {
     private final MemberService memberService;
     private final JwtProperties jwtProperties;
 
+    /**
+     * 사용자 로그아웃 API
+     * @param response Servlet 기반 웹에서 server -> client로 http 응답을 보내기 위한 객체, 자동 주입.
+     */
     @GetMapping("/logout")
     @Operation(summary = "사용자 로그아웃")
     public ResponseEntity<RsData<Void>> logout(HttpServletResponse response) {
@@ -54,6 +58,11 @@ public class ApiV1AuthController {
                 );
     }
 
+    /**
+     * refreshToken 기반으로 accessToken 재발급
+     * @param refreshToken 쿠키에 포함된 현재 로그인한 사용자의 refreshToken
+     * @param response Servlet 기반 웹에서 server -> client로 http 응답을 보내기 위한 객체, 자동 주입.
+     */
     @PostMapping("/refresh")
     @Operation(summary = "사용자 액세스 토큰 재발급 (리프레시 토큰이 유효할 경우)")
     public ResponseEntity<RsData<Void>> refreshToken(@CookieValue(name = "refreshToken", required = false) String refreshToken,

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/home/controller/HomeController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/home/controller/HomeController.java
@@ -4,12 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.tuna.zoopzoop.backend.domain.news.service.NewsSearchService;
-import reactor.core.publisher.Mono;
 
 import java.net.InetAddress;
 
@@ -60,15 +57,5 @@ public class HomeController {
                     <input type="submit" value="검색"/>
                 </form>
                 """.formatted(localHost.getHostName(), localHost.getHostAddress(), kakaoLoginUrl, googleLoginUrl, logoutUrl);
-    }
-
-    @GetMapping(value = "/search-news", produces = MediaType.TEXT_HTML_VALUE)
-    public Mono<String> searchNews(@RequestParam String query) {
-        return newsSearchService.searchNews(query, 5, 1, "sim")
-                .map("""
-                        <h1>검색 결과</h1>
-                        <pre>%s</pre>
-                        <a href="/">뒤로가기</a>
-                        """::formatted);
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/controller/ApiV1MemberController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/controller/ApiV1MemberController.java
@@ -32,6 +32,12 @@ public class ApiV1MemberController {
     /// api/v1/member/all : 모든 사용자 목록 조회 (GET)
     /// api/v1/member/{id} : id 기반 사용자 조회 (GET)
     /// api/v1/member?name={name} : 이름 기반 사용자 조회 (GET)
+
+    /**
+     * 현재 로그인한 사용자의 정보를 조회하는 API
+     * HTTP METHOD: GET
+     * @param userDetails @AuthenticationPrincipal로 받아오는 현재 사용자 정보
+     */
     @GetMapping("/me")
     @Operation(summary = "사용자 정보 조회")
     public ResponseEntity<RsData<ResBodyForGetMemberInfo>> getMemberInfo(
@@ -49,6 +55,12 @@ public class ApiV1MemberController {
                 );
     }
 
+    /**
+     * 현재 로그인한 사용자의 이름을 변경하는 API
+     * HTTP METHOD: PUT
+     * @param userDetails @AuthenticationPrincipal로 받아오는 현재 사용자 정보
+     * @param reqBodyForEditMemberName 수정할 닉네임을 받아오는 reqDto
+     */
     @PutMapping("/edit")
     @Operation(summary = "사용자 닉네임 수정")
     public ResponseEntity<RsData<ResBodyForEditMemberName>> editMemberName(
@@ -68,6 +80,12 @@ public class ApiV1MemberController {
                 );
     }
 
+    /**
+     * 현재 로그인한 사용자를 삭제하는 API
+     * 사용할 지 모르겠음.
+     * HTTP METHOD: DELETE
+     * @param userDetails @AuthenticationPrincipal로 받아오는 현재 사용자 정보
+     */
     @DeleteMapping
     @Operation(summary = "사용자 삭제")
     public ResponseEntity<RsData<Void>> deleteMember(
@@ -86,6 +104,10 @@ public class ApiV1MemberController {
                 );
     }
 
+    /**
+     * 모든 사용자의 정보를 조회하는 API
+     * HTTP METHOD: GET
+     */
     @GetMapping("/all")
     @Operation(summary = "모든 사용자 정보 조회")
     public ResponseEntity<RsData<List<ResBodyForGetMemberInfo>>> getMemberInfoAll(
@@ -105,6 +127,11 @@ public class ApiV1MemberController {
                 );
     }
 
+    /**
+     * ID 기반으로 사용자의 정보를 조회하는 API
+     * HTTP METHOD: GET
+     * @param id 조회할 사용자의 ID
+     */
     @GetMapping("/{id}")
     @Operation(summary = "id 기반 사용자 정보 조회")
     public ResponseEntity<RsData<ResBodyForGetMemberInfo>> getMemberInfoById(
@@ -122,6 +149,11 @@ public class ApiV1MemberController {
                 );
     }
 
+    /**
+     * 이름 기반으로 사용자의 정보를 조회하는 API
+     * HTTP METHOD: GET
+     * @param name 조회할 사용자의 name
+     */
     @GetMapping
     @Operation(summary = "이름 기반 사용자 정보 조회")
     public ResponseEntity<RsData<ResBodyForGetMemberInfo>> getMemberInfoByName(

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/service/MemberService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/service/MemberService.java
@@ -46,11 +46,6 @@ public class MemberService {
         );
     }
 
-//    public Member findByEmail(String email){
-//        return memberRepository.findByEmail(email).orElseThrow(() ->
-//                new NoResultException(email + " 이메일을 가진 사용자를 찾을 수 없습니다.")
-//        );
-//    }
     public List<Member> findAll(){ return memberRepository.findAll(); }
     public List<Member> findAllActive(){ return memberRepository.findByActiveTrue(); }
     public List<Member> findAllInactive(){ return memberRepository.findByActiveFalse(); }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/controller/ApiV1NewsController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/controller/ApiV1NewsController.java
@@ -19,14 +19,18 @@ import reactor.core.publisher.Mono;
 public class ApiV1NewsController {
     private final NewsSearchService newsSearchService;
 
+    /**
+     * 최신 뉴스 목록을 조회하는 API
+     * 한번에 100개를 조회 합니다.
+     * HTTP METHOD: GET
+     */
     @GetMapping
     @Operation(summary = "최신 뉴스 목록 조회")
     public Mono<ResponseEntity<RsData<ResBodyForNaverNews>>> searchRecentNews(
-            @RequestParam(defaultValue = "10") int display
     ) {
         // Naver 뉴스 API에선 Non-keyword 방식의 검색을 지원하지 않음.
         // 그래서 일단 그냥 검색 쿼리를 '뉴스'라고 지정하고 해 보았는데, 꽤나 좋은 결과를 받아옴. (목표하던 기능과 비슷함.)
-        return newsSearchService.searchNews("뉴스", display, 1, "date")
+        return newsSearchService.searchNews("뉴스", "date")
                 .map(response -> ResponseEntity
                         .status(HttpStatus.OK)
                         .body(new RsData<>(
@@ -36,17 +40,22 @@ public class ApiV1NewsController {
                         )));
     }
 
+    /**
+     * 입력한 키워드 기반으로 뉴스 목록을 조회하는 API
+     * HTTP METHOD: GET
+     * 한번에 100개를 조회 합니다.
+     * @param dto 키워드를 받아오는 reqDto
+     */
     @PostMapping("/keywords")
     @Operation(summary = "최신 뉴스 목록 조회")
     public Mono<ResponseEntity<RsData<ResBodyForNaverNews>>> searchNewsByKeywords(
-            @RequestParam(defaultValue = "10") int display,
             @RequestBody ReqBodyForKeyword dto
     ) {
         String query = String.join(" ", dto.keywords());
         // AND, OR 연산 쿼리를 지원한다고는 하는데, 정확한지는 모름.
         // String query = String.join("+", dto.keywords()); // AND 연산 키워드 검색
         // String query = String.join("|", dto.keywords()); // OR 연산 키워드 검색
-        return newsSearchService.searchNews(query, display, 1, "sim")
+        return newsSearchService.searchNews(query, "sim")
                 .map(response -> ResponseEntity
                         .status(HttpStatus.OK)
                         .body(new RsData<>(

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/dto/res/ResBodyForNaverNews.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/dto/res/ResBodyForNaverNews.java
@@ -3,10 +3,7 @@ package org.tuna.zoopzoop.backend.domain.news.dto.res;
 import java.util.List;
 
 public record ResBodyForNaverNews(
-        String lastBuildDate,
         int total,
-        int start,
-        int display,
         List<NewsItem> items
 ) {
     public record NewsItem(
@@ -24,7 +21,8 @@ public record ResBodyForNaverNews(
 
         private static String cleanText(String text) {
             if (text == null) return null;
-            return text.replaceAll("<.*?>", "");
+            String noTags = text.replaceAll("<.*?>", "");
+            return noTags.replaceAll("&[a-zA-Z0-9#]+;", "");
         }
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/service/NewsSearchService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/service/NewsSearchService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.tuna.zoopzoop.backend.domain.news.dto.res.ResBodyForNaverNews;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Service
@@ -23,37 +24,65 @@ public class NewsSearchService {
     /**
      * 네이버 뉴스 API
      * @param query 검색어 (UTF-8로 인코딩 필수)
-     * @param display 한 번에 표시할 결과 수 (기본 값 10, 최대 100)
-     * @param start 검색 시작 위치 (기본값 1, 최대 1000)
      * @param sort 정렬 방식 ("sim", "date") sim: 정확도 순, date: 날짜 순, 둘다 내림차 순 정렬.
      */
 
     /*
     Q. 어째서 WebClient를 사용하는가?
     A. WebClient -> 비동기/논블로킹 HTTP 클라이언트.
-    즉, 현재 우리 시스템처럼 여러명의 사용자가 뉴스 API를 통한 검색을 요청할 경우,
-    기존의 Spring MVC, RestTemplate를 사용하면 블로킹된 쓰레드가 바생하여 서버의 리소스를 효율적으로 사용하지 못함.
+       즉, 현재 우리 시스템처럼 여러명의 사용자가 뉴스 API를 통한 검색을 요청할 경우,
+       기존의 Spring MVC, RestTemplate를 사용하면 블로킹된 쓰레드가 바생하여 서버의 리소스를 효율적으로 사용하지 못함.
 
-    추가로, WebFlux의 Mono/Flux의 경우엔 Backpressure를 지원하므로, 데이터가 너무 많이 들어올 경우 서버가 감당 가능하도록 흐름을 조절.
-    *Backpressure(백프레셔) : 수신자가 처리할 수 있는 속도로 발신자가 데이터를 보내도록 하는 것.
+       추가로, WebFlux의 Mono/Flux의 경우엔 Backpressure를 지원하므로,
+       데이터가 너무 많이 들어올 경우 서버가 감당 가능하도록 흐름을 조절.
+       *Backpressure(백프레셔) : 수신자가 처리할 수 있는 속도로 발신자가 데이터를 보내도록 하는 것.
+
+    Q. 중복 뉴스나 불필요한 데이터는?
+    A. filter()를 통해 네이버 뉴스 본문 링크만 걸러내고,
+       distinct()를 적용하여 동일한 링크를 가진 뉴스는 제거.
+       → API가 중복된 데이터를 반환해도, 최종적으로는 고유한 뉴스만 내려줌.
+
+       n.news.naver.com 도메인의 아닌 경우, 아직 크롤링 기능을 지원할 지 미정인 상태이므로,
+       마찬가지로 예외 처리한다. (크롤링하지 않으면 요약 기능을 사용할 수 없기 때문.)
+
+    Q. display=10 으로 요청했는데, 링크 필터링으로 인해 결과가 10개보다 작을 경우는?
+    A. 한 페이지만 요청할 경우, 필터링과 중복 제거 과정에서 일부 데이터가 빠져 결과의 개수가 적을 수 있다.
+
+       그래서 현재 로직
+       1. 여러 페이지를 호출한다.(.range(0, 1000 / finalDisplay), 최대 1000건 까지.)
+       2. 필터링 & 중복 제거
+       3. display 값 만큼 최종 개수 제한(.take(display))
+       4. 그렇게 추출한 데이터를 collectList()로 모은 후, 다시 ResBodyForNaverNews로 감싸기.
+
+       위 과정을 거쳐도 개수가 부족한 경우엔 부족한 만큼 내보낸다.
     */
-
-    public Mono<ResBodyForNaverNews> searchNews(String query, Integer display, Integer start, String sort) {
-        int finalDisplay = (display == null) ? 10 : Math.min(display, 100);
-        int finalStart = (start == null) ? 1 : Math.min(start, 1000);
+    public Mono<ResBodyForNaverNews> searchNews(String query, String sort) {
+        int finalDisplay = 100;
         String finalSort = (sort == null || (!sort.equals("sim") && !sort.equals("date"))) ? "sim" : sort;
 
-        return webClient.get()
-                .uri(uriBuilder -> uriBuilder
-                        .path("v1/search/news.json")
-                        .queryParam("query", query)
-                        .queryParam("display", finalDisplay)
-                        .queryParam("start", finalStart)
-                        .queryParam("sort", finalSort)
-                        .build())
-                .header("X-Naver-Client-Id", client_id)
-                .header("X-Naver-Client-Secret", client_secret)
-                .retrieve()
-                .bodyToMono(ResBodyForNaverNews.class);
+        return Flux
+                .range(0, 10000 / finalDisplay)
+                .concatMap(page -> webClient.get()
+                        .uri(uriBuilder -> uriBuilder
+                                .path("v1/search/news.json")
+                                .queryParam("query", query)
+                                .queryParam("display", finalDisplay)
+                                .queryParam("start", page * finalDisplay + 1)
+                                .queryParam("sort", finalSort)
+                                .build())
+                        .header("X-Naver-Client-Id", client_id)
+                        .header("X-Naver-Client-Secret", client_secret)
+                        .retrieve()
+                        .bodyToMono(ResBodyForNaverNews.class)
+                        .flatMapMany(res -> Flux.fromIterable(res.items()))
+                        .filter(item -> item.link().startsWith("https://n.news.naver.com/"))
+                )
+                .distinct(ResBodyForNaverNews.NewsItem::link)
+                .take(100)
+                .collectList()
+                .map(items -> new ResBodyForNaverNews(
+                        items.size(),
+                        items
+                ));
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteController.java
@@ -5,16 +5,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.tuna.zoopzoop.backend.domain.member.dto.res.ResBodyForGetMemberInfo;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
-import org.tuna.zoopzoop.backend.domain.space.membership.dto.ResBodyForSpaceInvitationList;
 import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
-import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.ResBodyForSpaceInviteList;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.ResBodyForSpaceSave;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.SpaceMembershipInfoWithoutAuthority;
-import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
 import org.tuna.zoopzoop.backend.global.rsData.RsData;
 import org.tuna.zoopzoop.backend.global.security.jwt.CustomUserDetails;
@@ -100,5 +96,4 @@ public class ApiV1InviteController {
                 )
         );
     }
-
 }

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/news/service/NewsServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/news/service/NewsServiceTest.java
@@ -21,10 +21,7 @@ class NewsServiceTest {
     void newsJsonStructureTest() {
         // JSON 구조용 더미 데이터
         ResBodyForNaverNews dummyResponse = new ResBodyForNaverNews(
-                "Mon, 22 Sep 2025 17:35:10 +0900",  // lastBuildDate
                 505376,                                         // total
-                1,                                              // start
-                5,                                              // display
                 List.of(
                         new ResBodyForNaverNews.NewsItem(       // items
                                 "뉴스 제목",                    // title
@@ -39,10 +36,7 @@ class NewsServiceTest {
 
         // JSON 구조 확인
         result.doOnNext(res -> {
-            assertNotNull(res.lastBuildDate());
             assertNotNull(res.total());
-            assertNotNull(res.start());
-            assertNotNull(res.display());
             assertNotNull(res.items());
 
             res.items().forEach(item -> {


### PR DESCRIPTION
## 📢 기능 설명
### 기존 코드 변경 사항
NewsSearchService의 뉴스 검색 로직을 변경했습니다.
- 뉴스 검색을 고정된 100개의 뉴스를 가져오도록 변경 했습니다.
- m.news.naver.com 도메인을 제외한 링크는 검색에서 제외하도록 했습니다.
- 중복된 뉴스 링크를 가져오는 경우 제외하도록 했습니다.
- 목표하는 검색 개수(=100개)를 채우지 못하더라도 출력을 정상적으로 보내도록 변경 했습니다.
- 메소드에 사용하던 인자 값을 변경 했습니다. (display, start 삭제.)

### 추가 사항
일부 도메인의 API에 문서화 작업을 진행했습니다.
<br>


## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?