### PR TITLE
[feat/OPS-293] LiveBlocks를 위한 React-flow 데이터 관리 도메인 설계 완료. 테스트 추가.

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/controller/ApiV1GraphController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/controller/ApiV1GraphController.java
@@ -1,0 +1,60 @@
+package org.tuna.zoopzoop.backend.domain.graph.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.tuna.zoopzoop.backend.domain.graph.dto.BodyForReactFlow;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Graph;
+import org.tuna.zoopzoop.backend.domain.graph.service.GraphService;
+import org.tuna.zoopzoop.backend.global.rsData.RsData;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/graph")
+@Tag(name = "ApiV1GraphController", description = "React-flow 데이터 컨트롤러")
+public class ApiV1GraphController {
+    private final GraphService graphService;
+
+    /**
+     * LiveBlocks를 위한 React-flow 데이터 저장 API
+     * @param bodyForReactFlow React-flow 데이터를 가지고 있는 Dto
+     */
+    @PostMapping
+    @Operation(summary = "React-flow 데이터 저장")
+    public ResponseEntity<RsData<Void>> createGraph(
+            @RequestBody BodyForReactFlow bodyForReactFlow
+    ) {
+        Graph graph = bodyForReactFlow.toEntity();
+        graphService.saveGraph(graph);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new RsData<>(
+                        "200",
+                        "React-flow 데이터를 저장 했습니다.",
+                        null
+                ));
+    }
+
+    /**
+     * LiveBlocks를 위한 React-flow 데이터 조회 API
+     * @param id React-flow 데이터의 graph 식별 id
+     */
+    @GetMapping("/{id}")
+    @Operation(summary = "React-flow 데이터 조회")
+    public ResponseEntity<RsData<BodyForReactFlow>> getGraph(
+            @PathVariable Integer id
+    ) {
+        Graph graph = graphService.getGraph(id);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new RsData<>(
+                        "200",
+                        "ID: " + id + " 의 React-flow 데이터를 조회했습니다.",
+                        BodyForReactFlow.from(graph)
+                ));
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/dto/BodyForReactFlow.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/dto/BodyForReactFlow.java
@@ -1,0 +1,108 @@
+package org.tuna.zoopzoop.backend.domain.graph.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Edge;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Graph;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Node;
+import org.tuna.zoopzoop.backend.domain.graph.enums.EdgeType;
+import org.tuna.zoopzoop.backend.domain.graph.enums.NodeType;
+
+import java.util.List;
+import java.util.Map;
+
+// Request, Response 범용 Dto
+public record BodyForReactFlow(
+        List<NodeDto> nodes,
+        List<EdgeDto> edges
+) {
+    public record NodeDto(
+            @JsonProperty("id") String nodeKey,
+            @JsonProperty("type") String nodeType,
+            Map<String, String> data,
+            @JsonProperty("position") PositionDto positionDto
+    ) {
+        public record PositionDto(
+            @JsonProperty("x") double x,
+            @JsonProperty("y") double y
+    ) {}
+    }
+
+    public record EdgeDto(
+            @JsonProperty("id") String edgeKey,
+            @JsonProperty("source") String sourceNodeKey,
+            @JsonProperty("target") String targetNodeKey,
+            @JsonProperty("type") String edgeType,
+            @JsonProperty("animated") boolean isAnimated,
+            @JsonProperty("style") StyleDto styleDto
+    ) {
+        public record StyleDto(
+                String stroke,
+                Double strokeWidth
+        ) {}
+    }
+
+    // DTO -> Entity, BodyForReactFlow를 Graph 엔티티로 변환
+    public Graph toEntity() {
+        Graph graph = new Graph();
+
+        List<Node> nodeEntities = this.nodes().stream()
+                .map(dto -> {
+                    Node node = new Node();
+                    node.setNodeKey(dto.nodeKey());
+                    node.setNodeType(NodeType.valueOf(dto.nodeType().toUpperCase())); // string → enum
+                    node.setData(dto.data());
+                    node.setPositonX(dto.positionDto().x());
+                    node.setPositonY(dto.positionDto().y());
+                    node.setGraph(graph); // 연관관계 설정
+                    return node;
+                })
+                .toList();
+
+        List<Edge> edgeEntities = this.edges().stream()
+                .map(dto -> {
+                    Edge edge = new Edge();
+                    edge.setEdgeKey(dto.edgeKey());
+                    edge.setSourceNodeKey(dto.sourceNodeKey());
+                    edge.setTargetNodeKey(dto.targetNodeKey());
+                    edge.setEdgeType(EdgeType.valueOf(dto.edgeType().toUpperCase())); // string → enum
+                    edge.setAnimated(dto.isAnimated());
+                    if (dto.styleDto() != null) {
+                        edge.setStroke(dto.styleDto().stroke());
+                        edge.setStrokeWidth(dto.styleDto().strokeWidth());
+                    }
+                    edge.setGraph(graph); // 연관관계 설정
+                    return edge;
+                })
+                .toList();
+
+        graph.getNodes().addAll(nodeEntities);
+        graph.getEdges().addAll(edgeEntities);
+
+        return graph;
+    }
+
+    // Entity -> DTO, Graph 엔티티를 ResBodyForReactFlow로 변환
+    public static BodyForReactFlow from(Graph graph) {
+        List<NodeDto> nodeDtos = graph.getNodes().stream()
+                .map(n -> new NodeDto(
+                        n.getNodeKey(),
+                        n.getNodeType().name().toLowerCase(), // enum → 소문자
+                        n.getData(),
+                        new NodeDto.PositionDto(n.getPositonX(), n.getPositonY())
+                ))
+                .toList();
+
+        List<EdgeDto> edgeDtos = graph.getEdges().stream()
+                .map(e -> new EdgeDto(
+                        e.getEdgeKey(),
+                        e.getSourceNodeKey(),
+                        e.getTargetNodeKey(),
+                        e.getEdgeType().name().toLowerCase(), // enum → 소문자
+                        e.isAnimated(),
+                        new EdgeDto.StyleDto(e.getStroke(), e.getStrokeWidth())
+                ))
+                .toList();
+
+        return new BodyForReactFlow(nodeDtos, edgeDtos);
+    }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/dto/BodyForReactFlow.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/dto/BodyForReactFlow.java
@@ -49,7 +49,7 @@ public record BodyForReactFlow(
                 .map(dto -> {
                     Node node = new Node();
                     node.setNodeKey(dto.nodeKey());
-                    node.setNodeType(NodeType.valueOf(dto.nodeType().toUpperCase())); // string → enum
+                    node.setNodeType(NodeType.valueOf(dto.nodeType().toUpperCase()));
                     node.setData(dto.data());
                     node.setPositonX(dto.positionDto().x());
                     node.setPositonY(dto.positionDto().y());
@@ -64,7 +64,7 @@ public record BodyForReactFlow(
                     edge.setEdgeKey(dto.edgeKey());
                     edge.setSourceNodeKey(dto.sourceNodeKey());
                     edge.setTargetNodeKey(dto.targetNodeKey());
-                    edge.setEdgeType(EdgeType.valueOf(dto.edgeType().toUpperCase())); // string → enum
+                    edge.setEdgeType(EdgeType.valueOf(dto.edgeType().toUpperCase()));
                     edge.setAnimated(dto.isAnimated());
                     if (dto.styleDto() != null) {
                         edge.setStroke(dto.styleDto().stroke());
@@ -86,7 +86,7 @@ public record BodyForReactFlow(
         List<NodeDto> nodeDtos = graph.getNodes().stream()
                 .map(n -> new NodeDto(
                         n.getNodeKey(),
-                        n.getNodeType().name().toLowerCase(), // enum → 소문자
+                        n.getNodeType().name().toUpperCase(),
                         n.getData(),
                         new NodeDto.PositionDto(n.getPositonX(), n.getPositonY())
                 ))
@@ -97,7 +97,7 @@ public record BodyForReactFlow(
                         e.getEdgeKey(),
                         e.getSourceNodeKey(),
                         e.getTargetNodeKey(),
-                        e.getEdgeType().name().toLowerCase(), // enum → 소문자
+                        e.getEdgeType().name().toUpperCase(),
                         e.isAnimated(),
                         new EdgeDto.StyleDto(e.getStroke(), e.getStrokeWidth())
                 ))

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/entity/Edge.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/entity/Edge.java
@@ -1,0 +1,38 @@
+package org.tuna.zoopzoop.backend.domain.graph.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.tuna.zoopzoop.backend.domain.graph.enums.EdgeType;
+import org.tuna.zoopzoop.backend.global.jpa.entity.BaseEntity;
+
+@Getter
+@Setter
+@Entity
+public class Edge extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "graph_id")
+    private Graph graph;
+
+    @Column
+    private String edgeKey;
+
+    @Column
+    private String sourceNodeKey;
+
+    @Column
+    private String targetNodeKey;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private EdgeType edgeType;
+
+    @Column
+    boolean isAnimated;
+
+    @Column
+    private String stroke;
+
+    @Column
+    private Double strokeWidth;
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/entity/Graph.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/entity/Graph.java
@@ -1,0 +1,22 @@
+package org.tuna.zoopzoop.backend.domain.graph.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.Setter;
+import org.tuna.zoopzoop.backend.global.jpa.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+public class Graph extends BaseEntity {
+    @OneToMany(mappedBy = "graph", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Node> nodes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "graph", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Edge> edges = new ArrayList<>();
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/entity/Node.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/entity/Node.java
@@ -1,0 +1,38 @@
+package org.tuna.zoopzoop.backend.domain.graph.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.tuna.zoopzoop.backend.domain.graph.enums.NodeType;
+import org.tuna.zoopzoop.backend.global.jpa.entity.BaseEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@Entity
+public class Node extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "graph_id")
+    private Graph graph;
+
+    @Column
+    private String nodeKey;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private NodeType nodeType;
+
+    @ElementCollection
+    @CollectionTable(name = "node_data", joinColumns = @JoinColumn(name = "node_id"))
+    @MapKeyColumn(name = "key")
+    @Column(name = "value")
+    private Map<String, String> data = new HashMap<>();
+
+    @Column
+    private double positonX;
+
+    @Column
+    private double positonY;
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/enums/EdgeType.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/enums/EdgeType.java
@@ -1,0 +1,8 @@
+package org.tuna.zoopzoop.backend.domain.graph.enums;
+
+public enum EdgeType {
+    DEFAULT,
+    STRAIGHT,
+    STEP,
+    SMOOTHSTEP
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/enums/NodeType.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/enums/NodeType.java
@@ -1,0 +1,5 @@
+package org.tuna.zoopzoop.backend.domain.graph.enums;
+
+public enum NodeType {
+    CUSTOM
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/repository/EdgeRepository.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/repository/EdgeRepository.java
@@ -1,0 +1,7 @@
+package org.tuna.zoopzoop.backend.domain.graph.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Edge;
+
+public interface EdgeRepository extends JpaRepository<Edge,Integer> {
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/repository/GraphRepository.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/repository/GraphRepository.java
@@ -1,0 +1,10 @@
+package org.tuna.zoopzoop.backend.domain.graph.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Graph;
+
+import java.util.Optional;
+
+public interface GraphRepository extends JpaRepository<Graph,Integer> {
+    Optional<Graph> findGraphById(Integer id);
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/repository/NodeRepository.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/repository/NodeRepository.java
@@ -1,0 +1,7 @@
+package org.tuna.zoopzoop.backend.domain.graph.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Node;
+
+public interface NodeRepository extends JpaRepository<Node,Integer> {
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/graph/service/GraphService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/graph/service/GraphService.java
@@ -1,0 +1,26 @@
+package org.tuna.zoopzoop.backend.domain.graph.service;
+
+import jakarta.persistence.NoResultException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Graph;
+import org.tuna.zoopzoop.backend.domain.graph.repository.GraphRepository;
+
+@Service
+@RequiredArgsConstructor
+public class GraphService {
+    private final GraphRepository graphRepository;
+
+    @Transactional
+    public Graph saveGraph(Graph graph) {
+        return graphRepository.save(graph);
+    }
+
+    public Graph getGraph(Integer id) {
+        return graphRepository.findGraphById(id).orElseThrow(() ->
+                new NoResultException(id + " id를 가진 그래프를 찾을 수 없습니다.")
+        );
+    }
+}
+

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/member/entity/Member.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/member/entity/Member.java
@@ -9,6 +9,7 @@ import org.tuna.zoopzoop.backend.domain.archive.archive.entity.PersonalArchive;
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
 import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
 import org.tuna.zoopzoop.backend.global.jpa.entity.BaseEntity;
+
 import java.util.List;
 
 @Setter

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(MockitoExtension.class)
 @Transactional
+@ActiveProfiles("test")
 class FolderControllerTest {
 
     @Mock private FolderService folderService;

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.archive.folder.dto.FolderResponse;
 import org.tuna.zoopzoop.backend.domain.archive.folder.dto.reqBodyForCreateFolder;
 import org.tuna.zoopzoop.backend.domain.archive.folder.service.FolderService;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
+@Transactional
 class FolderControllerTest {
 
     @Mock private FolderService folderService;

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.archive.archive.entity.Archive;
 import org.tuna.zoopzoop.backend.domain.archive.archive.entity.PersonalArchive;
 import org.tuna.zoopzoop.backend.domain.archive.archive.repository.PersonalArchiveRepository;
@@ -32,6 +33,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@Transactional
 class FolderServiceTest {
 
     @Mock private MemberRepository memberRepository;

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.archive.archive.entity.Archive;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @Transactional
+@ActiveProfiles("test")
 class FolderServiceTest {
 
     @Mock private MemberRepository memberRepository;

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/graph/controller/GraphControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/graph/controller/GraphControllerTest.java
@@ -1,5 +1,6 @@
 package org.tuna.zoopzoop.backend.domain.graph.controller;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,12 @@ class GraphControllerTest {
     @BeforeEach
     void setUp() {
         graphRepository.deleteAll(); // 테스트 전 DB 초기화
+    }
+
+    @AfterEach
+    void cleanUp() {
+        graphRepository.deleteAll(); // Graph만 삭제
+        // 필요하면 다른 Repository도 순서대로 삭제
     }
 
     // 단위 테스트가 백엔드 컨벡션 원칙이나, 서비스 특성 상 단위 테스트가 어려워
@@ -117,4 +124,6 @@ class GraphControllerTest {
                 .andExpect(jsonPath("$.data.edges[0].id").value("e1-2"))
                 .andExpect(jsonPath("$.data.edges[0].animated").value(true));
     }
+
+
 }

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/graph/controller/GraphControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/graph/controller/GraphControllerTest.java
@@ -57,7 +57,7 @@ class GraphControllerTest {
                 "nodes": [
                     {
                         "id": "1",
-                        "type": "custom",
+                        "type": "CUSTOM",
                         "data": {
                             "title": "노드1",
                             "description": "설명1"
@@ -69,7 +69,7 @@ class GraphControllerTest {
                     },
                     {
                         "id": "2",
-                        "type": "custom",
+                        "type": "CUSTOM",
                         "data": {
                             "title": "노드2"
                         },
@@ -84,7 +84,7 @@ class GraphControllerTest {
                         "id": "e1-2",
                         "source": "1",
                         "target": "2",
-                        "type": "smoothstep",
+                        "type": "SMOOTHSTEP",
                         "animated": true,
                         "style": {
                             "stroke": "#999",
@@ -119,7 +119,7 @@ class GraphControllerTest {
                 .andExpect(jsonPath("$.data.nodes", hasSize(2)))
                 .andExpect(jsonPath("$.data.edges", hasSize(1)))
                 .andExpect(jsonPath("$.data.nodes[0].id").value("1"))
-                .andExpect(jsonPath("$.data.nodes[0].type").value("custom"))
+                .andExpect(jsonPath("$.data.nodes[0].type").value("CUSTOM"))
                 .andExpect(jsonPath("$.data.nodes[0].data.title").value("노드1"))
                 .andExpect(jsonPath("$.data.edges[0].id").value("e1-2"))
                 .andExpect(jsonPath("$.data.edges[0].animated").value(true));

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/graph/controller/GraphControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/graph/controller/GraphControllerTest.java
@@ -1,0 +1,120 @@
+package org.tuna.zoopzoop.backend.domain.graph.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Graph;
+import org.tuna.zoopzoop.backend.domain.graph.repository.GraphRepository;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@Transactional
+class GraphControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GraphRepository graphRepository;
+
+    @BeforeEach
+    void setUp() {
+        graphRepository.deleteAll(); // 테스트 전 DB 초기화
+    }
+
+    // 단위 테스트가 백엔드 컨벡션 원칙이나, 서비스 특성 상 단위 테스트가 어려워
+    // 일단 통합 테스트로 진행합니다.
+    @Test
+    @DisplayName("React-flow 데이터 저장 및 조회 테스트 - JSON 방식")
+    void createAndGetGraphTest() throws Exception {
+        // 테스트 용 React-flow JSON
+        String jsonBody = """
+            {
+                "nodes": [
+                    {
+                        "id": "1",
+                        "type": "custom",
+                        "data": {
+                            "title": "노드1",
+                            "description": "설명1"
+                        },
+                        "position": {
+                            "x": 100,
+                            "y": 200
+                        }
+                    },
+                    {
+                        "id": "2",
+                        "type": "custom",
+                        "data": {
+                            "title": "노드2"
+                        },
+                        "position": {
+                            "x": 300,
+                            "y": 400
+                        }
+                    }
+                ],
+                "edges": [
+                    {
+                        "id": "e1-2",
+                        "source": "1",
+                        "target": "2",
+                        "type": "smoothstep",
+                        "animated": true,
+                        "style": {
+                            "stroke": "#999",
+                            "strokeWidth": 2.0
+                        }
+                    }
+                ]
+            }
+            """;
+
+        // React-flow 데이터 저장
+        mockMvc.perform(post("/api/v1/graph")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("200"))
+                .andExpect(jsonPath("$.msg").value("React-flow 데이터를 저장 했습니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        // DB 무결성 검증
+        assertEquals(1, graphRepository.count());
+        Graph savedGraph = graphRepository.findAll().get(0);
+        assertEquals(2, savedGraph.getNodes().size());
+        assertEquals(1, savedGraph.getEdges().size());
+
+        // 저장된 React-flow 데이터 조회
+        mockMvc.perform(get("/api/v1/graph/{id}", savedGraph.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("200"))
+                .andExpect(jsonPath("$.msg").value("ID: " + savedGraph.getId() + " 의 React-flow 데이터를 조회했습니다."))
+                .andExpect(jsonPath("$.data.nodes", hasSize(2)))
+                .andExpect(jsonPath("$.data.edges", hasSize(1)))
+                .andExpect(jsonPath("$.data.nodes[0].id").value("1"))
+                .andExpect(jsonPath("$.data.nodes[0].type").value("custom"))
+                .andExpect(jsonPath("$.data.nodes[0].data.title").value("노드1"))
+                .andExpect(jsonPath("$.data.edges[0].id").value("e1-2"))
+                .andExpect(jsonPath("$.data.edges[0].animated").value(true));
+    }
+}

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/graph/service/GraphServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/graph/service/GraphServiceTest.java
@@ -1,0 +1,71 @@
+package org.tuna.zoopzoop.backend.domain.graph.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Edge;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Graph;
+import org.tuna.zoopzoop.backend.domain.graph.entity.Node;
+import org.tuna.zoopzoop.backend.domain.graph.enums.EdgeType;
+import org.tuna.zoopzoop.backend.domain.graph.enums.NodeType;
+import org.tuna.zoopzoop.backend.domain.graph.repository.GraphRepository;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class GraphServiceTest {
+    @Autowired
+    private GraphRepository graphRepository;
+
+    @Test
+    @DisplayName("Graph + Node + Edge 저장 테스트")
+    void saveGraphWithNodesAndEdges() {
+        // Graph 생성
+        Graph graph = new Graph();
+
+        // Node 생성
+        Node node1 = new Node();
+        node1.setNodeKey("1");
+        node1.setNodeType(NodeType.CUSTOM);
+        node1.setData(Map.of("title", "노드 제목", "description", "노드 설명"));
+        node1.setPositonX(100);
+        node1.setPositonY(200);
+        node1.setGraph(graph); // 연관관계 주인 설정
+
+        Node node2 = new Node();
+        node2.setNodeKey("2");
+        node2.setNodeType(NodeType.CUSTOM);
+        node2.setPositonX(300);
+        node2.setPositonY(400);
+        node2.setGraph(graph);
+
+        // Edge 생성
+        Edge edge = new Edge();
+        edge.setEdgeKey("e1-2");
+        edge.setSourceNodeKey("1");
+        edge.setTargetNodeKey("2");
+        edge.setEdgeType(EdgeType.SMOOTHSTEP);
+        edge.setAnimated(true);
+        edge.setStroke("#999");
+        edge.setStrokeWidth(2.0);
+        edge.setGraph(graph);
+
+        // graph와 연결
+        graph.getNodes().add(node1);
+        graph.getNodes().add(node2);
+        graph.getEdges().add(edge);
+        Graph savedGraph = graphRepository.save(graph);
+
+        assertNotNull(savedGraph.getId());
+        assertEquals(2, savedGraph.getNodes().size());
+        assertEquals(1, savedGraph.getEdges().size());
+    }
+}

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/graph/service/GraphServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/graph/service/GraphServiceTest.java
@@ -1,5 +1,6 @@
 package org.tuna.zoopzoop.backend.domain.graph.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class GraphServiceTest {
     @Autowired
     private GraphRepository graphRepository;
+
+    @AfterEach
+    void cleanUp() {
+        graphRepository.deleteAll(); // Graph만 삭제
+        // 필요하면 다른 Repository도 순서대로 삭제
+    }
 
     @Test
     @DisplayName("Graph + Node + Edge 저장 테스트")

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
@@ -1,10 +1,9 @@
 package org.tuna.zoopzoop.backend.domain.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,7 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MemberControllerTest {
     @Autowired
     private MemberService memberService;
@@ -40,7 +38,7 @@ public class MemberControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @BeforeAll
+    @BeforeEach
     void setUp() {
         Member member1 = memberService.createMember(
                 "test1",

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
@@ -1,10 +1,7 @@
 package org.tuna.zoopzoop.backend.domain.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -60,6 +57,12 @@ public class MemberControllerTest {
                 "3333",
                 Provider.GOOGLE
         );
+    }
+
+    @AfterAll
+    void cleanUp() {
+        memberRepository.deleteAll(); // Graph만 삭제
+        // 필요하면 다른 Repository도 순서대로 삭제
     }
 
     @Test

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/controller/MemberControllerTest.java
@@ -1,9 +1,10 @@
 package org.tuna.zoopzoop.backend.domain.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MemberControllerTest {
     @Autowired
     private MemberService memberService;
@@ -38,7 +40,7 @@ public class MemberControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @BeforeEach
+    @BeforeAll
     void setUp() {
         Member member1 = memberService.createMember(
                 "test1",

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/repository/MemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.tuna.zoopzoop.backend.domain.member.repository;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,11 @@ public class MemberRepositoryTest {
     @Autowired
     MemberRepository memberRepository;
 
+    @AfterEach
+    void cleanUp() {
+        memberRepository.deleteAll(); // Graph만 삭제
+        // 필요하면 다른 Repository도 순서대로 삭제
+    }
 
     @Test
     @DisplayName("Member 저장 시 PersonalArchive + Archive + default 폴더가 자동 생성된다")

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/service/MemberServiceTest.java
@@ -28,13 +28,13 @@ class MemberServiceTest {
     @BeforeEach
     void setUp() {
         Member member1 = memberService.createMember(
-                "test1",
+                "testtest1",
                 "url",
                 "1111",
                 Provider.KAKAO
         );
         Member member2 = memberService.createMember(
-                "test2",
+                "testtest2",
                 "url",
                 "2222",
                 Provider.GOOGLE

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package org.tuna.zoopzoop.backend.domain.member.service;
 
 import jakarta.persistence.NoResultException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,12 @@ class MemberServiceTest {
                 "3333",
                 Provider.KAKAO
         );
+    }
+
+    @AfterEach
+    void cleanUp() {
+        memberRepository.deleteAll(); // Graph만 삭제
+        // 필요하면 다른 Repository도 순서대로 삭제
     }
 
     @Test


### PR DESCRIPTION
## 📢 기능 설명
### 추가사항
```
[
 {
      id: '1',
      type: 'custom',  // 노드 타입
      data: {
       // 커스텀 정보 ex) title, description, thumbnail ...
      },
      position: { x: 0, y: 0 } // 위치 좌표
    },
    {
      id: '1',
      type: 'custom',  // 노드 타입
      data: {
       // 커스텀 정보 ex) title, description, thumbnail ...
      },
      position: { x: 0, y: 0 } // 위치 좌표
    }
   ]
   
   // edge 연결선 정보
   [
	  {
	    id: 'e1-2',
	    source: '1',    // 시작 노드 ID
	    target: '2',    // 끝 노드 ID
	    
	    type: 'smoothstep',  // 'default' | 'straight' | 'step' | 'smoothstep'
	    animated: true,      // 흐르는 애니메이션
	    style: { 
	      stroke: '#999',    // 선 색상
	      strokeWidth: 2     // 선 두께
		   }
 }
]
```
이전에 제공 받은 React-flow 데이터의 저장 및 조회를 위한 도메인, API를 구현 했습니다.
- api/v1/graph (POST) //  React-flow 데이터 저장
- api/v1/graph/{id} (GET) // React-flow 데이터 조회

Dto 고도화를 통해 입력 데이터와 출력 데이터가 동일하도록 구성했습니다.
<br>


## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

