### PR TITLE
[refactor/OPS-308] 로그인 local/prod 환경 도메인 분리

### DIFF
--- a/.github/workflows/test-server.yml
+++ b/.github/workflows/test-server.yml
@@ -55,11 +55,18 @@ jobs:
           echo "${{ secrets.APPLICATION_SECRET_YML }}" > src/main/resources/application-secrets.yml
           echo "OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}" >> src/main/resources/application-secrets.yml
 
-      # 6. Gradle 테스트 실행
+      # 6. application-secrets-server.yml 생성
+      - name: Generate application-secrets-server.yml
+        run: |
+          mkdir -p src/main/resources
+          echo "${{ secrets.APPLICATION_SECRET_SERVER_YML }}" > src/main/resources/application-secrets-server.yml
+          echo "OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}" >> src/main/resources/application-secrets-server.yml
+
+      # 7. Gradle 테스트 실행
       - name: Test with Gradle
         run: ./gradlew test
 
-      # 7. 테스트 결과 요약 출력
+      # 8. 테스트 결과 요약 출력
       - name: Show test results
         run: |
           echo "==== Test Results ===="
@@ -76,11 +83,11 @@ jobs:
             echo "No test results found."
           fi
 
-      # 8. Gradle 빌드 실행 (테스트 성공 시)
+      # 9. Gradle 빌드 실행 (테스트 성공 시)
       - name: Build with Gradle
         run: ./gradlew build
 
-      # 9. GHCR 로그인
+      # 10. GHCR 로그인
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
@@ -88,7 +95,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # 10. Docker 이미지 빌드 & 푸시
+      # 11. Docker 이미지 빌드 & 푸시
       - name: Build & Push Docker Image
         run: |
           IMAGE_NAME=ghcr.io/${{ github.repository }}/zoopzoop

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/home/controller/HomeController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/home/controller/HomeController.java
@@ -30,9 +30,9 @@ public class HomeController {
     public String main() {
         InetAddress localHost = getLocalHost();
 
-        String kakaoLoginUrl = "http://localhost:8080/oauth2/authorization/kakao";
-        String googleLoginUrl = "http://localhost:8080/oauth2/authorization/google";
-        String logoutUrl = "http://localhost:8080/api/v1/auth/logout";
+        String kakaoLoginUrl = "/oauth2/authorization/kakao";
+        String googleLoginUrl = "/oauth2/authorization/google";
+        String logoutUrl = "/api/v1/auth/logout";
 
         return """
                 <h1>API 서버</h1>


### PR DESCRIPTION
## 📢 기능 설명

Local 테스트 환경(http://localhost:8080)과 Prod(=server) 환경에서 사용하는 도메인을 분리 했습니다.


도메인 분리에 맞춰 ci-workflow를 수정 했습니다.
<br>


## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

