### PR TITLE
fix : ci 시 secrets 에서 S3 관련 시크릿 값 삭제하도록 변경(버킷명 제외)

### DIFF
--- a/.github/workflows/test-server-ci.yml
+++ b/.github/workflows/test-server-ci.yml
@@ -59,7 +59,8 @@ jobs:
           echo "spring.cloud.aws.credentials.access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}" >> src/main/resources/application-secrets.yml
           echo "spring.cloud.aws.credentials.secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> src/main/resources/application-secrets.yml
           echo "spring.cloud.aws.s3.bucket: ${{ secrets.AWS_S3_BUCKET_NAME }}" >> src/main/resources/application-secrets.yml
-          echo "spring.cloud.aws.stack : false" >> src/main/resources/application-secrets.yml
+          echo "spring.cloud.aws.stack.auto : false" >> src/main/resources/application-secrets.yml
+
       # 6. application-secrets-server.yml 생성
       - name: Generate application-secrets-server.yml
         run: |
@@ -87,6 +88,15 @@ jobs:
           else
             echo "No test results found."
           fi
+
+      # 8-1. S3 자격 증명 제거 (빌드 전에만)
+      - name: Remove only S3 credentials before building
+        run: |
+          CONFIG_FILE="src/main/resources/application-secrets.yml"
+          sed -i '/spring.cloud.aws.credentials.access-key/d' $CONFIG_FILE
+          sed -i '/spring.cloud.aws.credentials.secret-key/d' $CONFIG_FILE
+          sed -i '/spring.cloud.aws.region.static/d' $CONFIG_FILE
+          sed -i '/spring.cloud.aws.stack.auto/d' $CONFIG_FILE
 
       # 9. Gradle 빌드 실행 (테스트 성공 시)
       - name: Build with Gradle

--- a/.github/workflows/test-server-ci.yml
+++ b/.github/workflows/test-server-ci.yml
@@ -100,7 +100,7 @@ jobs:
 
       # 9. Gradle 빌드 실행 (테스트 성공 시)
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -x test
 
       # 10. GHCR 로그인
       - name: Log in to GHCR

--- a/.github/workflows/test-server-ci.yml
+++ b/.github/workflows/test-server-ci.yml
@@ -59,7 +59,7 @@ jobs:
           echo "spring.cloud.aws.credentials.access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}" >> src/main/resources/application-secrets.yml
           echo "spring.cloud.aws.credentials.secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}" >> src/main/resources/application-secrets.yml
           echo "spring.cloud.aws.s3.bucket: ${{ secrets.AWS_S3_BUCKET_NAME }}" >> src/main/resources/application-secrets.yml
-          echo "spring.cloud.aws.stack.auto : false" >> src/main/resources/application-secrets.yml
+          echo "spring.cloud.aws.stack.auto: false" >> src/main/resources/application-secrets.yml
 
       # 6. application-secrets-server.yml 생성
       - name: Generate application-secrets-server.yml


### PR DESCRIPTION
## 📢 기능 설명
- CI 시, 테스트 후 도커 이미지 빌드 작업 전에 secrets.yml에서 S3 관련 시크릿 값(토큰)을 삭제하도록 변경
- EC2 의 S3 권한과 충돌 방지
- 단, S3 bucket 명은 남겨둔다.
- 이미 테스트를 한번 통과했기 때문에, 이후 jar 빌드 시에는 테스트를 돌리지 않도록 한다.
- 
<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] CI 로직 : S3 시크릿 값을 포함하는 secrets.yml 생성 -> 테스트 실행 -> secrets.yml에서 S3 시크릿 값 삭제 -> 테스트 없이 빌드 -> 도커 이미지 빌드, GHCR 에 업로드
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

