### PR TITLE
fix : SpringDoc과 Spring AI 간 의존성 충돌 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     // Spring AI
-    implementation "org.springframework.ai:spring-ai-starter-model-openai"
+    implementation ('org.springframework.ai:spring-ai-starter-model-openai'){
+        exclude group: 'io.swagger.core.v3', module: 'swagger-annotations'
+    }
 
     // 크롤링
     implementation("org.jsoup:jsoup:1.21.2")


### PR DESCRIPTION
## 📢 기능 설명

🚨 문제 상황
Swagger API 문서 접속 불가 (/swagger-ui/index.html)
500 에러: NoSuchMethodError: validationGroups() 발생
기존에 잘 작동하던 SpringDoc이 갑자기 동작하지 않음

🔍 원인 분석
의존성 버전 충돌 발견:

SpringDoc 2.8.9: swagger-annotations-jakarta:2.2.30 사용
Spring AI: swagger-annotations:2.2.25 사용
두 라이브러리가 서로 다른 Swagger 버전을 참조하여 충돌

bash# 충돌 확인 명령어
./gradlew dependencyInsight --dependency=swagger-annotations --configuration runtimeClasspath
✅ 해결 방법
Spring AI에서 불필요한 Swagger 의존성 제외:
gradle// build.gradle 수정
implementation('org.springframework.ai:spring-ai-starter-model-openai') {
    **exclude group: 'io.swagger.core.v3', module: 'swagger-annotations'**
}

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

