### PR TITLE
[refactor/OPS-354] 테스트 케이스 사용 프로필 변경.

### DIFF
--- a/src/test/java/org/tuna/zoopzoop/backend/BackendApplicationTests.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/BackendApplicationTests.java
@@ -2,7 +2,9 @@ package org.tuna.zoopzoop.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class BackendApplicationTests {
 

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
@@ -42,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Transactional
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class FolderControllerIntegrationTest {
+class FolderControllerTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/service/AiServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/service/AiServiceTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.test.context.ActiveProfiles;
 import org.tuna.zoopzoop.backend.domain.datasource.ai.dto.AnalyzeContentDto;
 import org.tuna.zoopzoop.backend.domain.datasource.ai.service.AiService;
 import org.tuna.zoopzoop.backend.domain.datasource.entity.Category;
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class AiServiceTest {
     @Mock

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/service/CrawlerManagerServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/service/CrawlerManagerServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.tuna.zoopzoop.backend.domain.datasource.crawler.dto.CrawlerResult;
 import org.tuna.zoopzoop.backend.domain.datasource.crawler.dto.SpecificSiteDto;
 import org.tuna.zoopzoop.backend.domain.datasource.crawler.dto.UnspecificSiteDto;
@@ -27,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 public class CrawlerManagerServiceTest {
     @InjectMocks

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/service/DataSourceServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/service/DataSourceServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.tuna.zoopzoop.backend.domain.archive.archive.entity.PersonalArchive;
 import org.tuna.zoopzoop.backend.domain.archive.archive.repository.PersonalArchiveRepository;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class DataSourceServiceTest {
 

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/member/repository/MemberRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.tuna.zoopzoop.backend.domain.archive.archive.entity.Archive;
 import org.tuna.zoopzoop.backend.domain.archive.folder.entity.Folder;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
 public class MemberRepositoryTest {


### PR DESCRIPTION
## 📢 기능 설명

- 일부 테스트의 active profile을 test로 변경 했습니다.
- FolderControllerTest의 경우 선언된 클래스와 이름이 맞지 않아 수정했습니다.
<br>


## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

