### PR TITLE
[feat/OPS-358] Redis 도입 및 Redis Config 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,9 @@ dependencies {
     
     // Apache Commons Codec
     implementation"commons-codec:commons-codec:1.19.0"
+
+    // Redis (Spring starter)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/auth/controller/ApiV1AuthController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/auth/controller/ApiV1AuthController.java
@@ -69,7 +69,6 @@ public class ApiV1AuthController {
      * @param sessionId 쿠키에 포함된 현재 로그인한 사용자의 sessionId.
      * @param response Servlet 기반 웹에서 server -> client로 http 응답을 보내기 위한 객체, 자동 주입.
      */
-
     @PostMapping("/refresh")
     @Operation(summary = "사용자 액세스 토큰 재발급 (서버 저장 RefreshToken 사용)")
     public ResponseEntity<RsData<Void>> refreshToken(
@@ -77,7 +76,6 @@ public class ApiV1AuthController {
             String sessionId,
             HttpServletResponse response
     ) {
-
         if (sessionId == null) {
             return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
@@ -91,7 +89,11 @@ public class ApiV1AuthController {
         } catch (AuthenticationException e) {
             return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
-                    .body(new RsData<>("401", e.getMessage(), null));
+                    .body(new RsData<>(
+                            "401",
+                            e.getMessage(),
+                            null
+                    ));
         }
 
         String refreshToken = refreshTokenEntity.getRefreshToken();
@@ -126,7 +128,6 @@ public class ApiV1AuthController {
      * 확장프로그램의 액세스 토큰 발급을 위한 백그라운드 풀링에 대응하는 API
      * @param state 확장프로그램 로그인 시 전달한 state 값.
      */
-
     @GetMapping("/result")
     @Operation(summary = "확장프로그램 백그라운드 풀링 대응 API")
     public ResponseEntity<RsData<AuthResultData>> pullingResult(

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/auth/dto/AuthResultData.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/auth/dto/AuthResultData.java
@@ -1,19 +1,15 @@
 package org.tuna.zoopzoop.backend.domain.auth.dto;
 
-public class AuthResultData {
-    private final String accessToken;
-    private final String sessionId;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-    public AuthResultData(String accessToken, String sessionId) {
-        this.accessToken = accessToken;
-        this.sessionId = sessionId;
-    }
+import java.io.Serializable;
 
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    public String getSessionId() {
-        return sessionId;
-    }
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthResultData implements Serializable {
+    private String accessToken;
+    private String sessionId;
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/auth/entity/AuthResult.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/auth/entity/AuthResult.java
@@ -1,23 +1,26 @@
 package org.tuna.zoopzoop.backend.domain.auth.entity;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.tuna.zoopzoop.backend.domain.auth.dto.AuthResultData;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+
+import java.time.Duration;
 
 @Component
+@RequiredArgsConstructor
 public class AuthResult {
-    private final Map<String, AuthResultData> results = new ConcurrentHashMap<>();
+    private final RedisTemplate<String, AuthResultData> redisTemplate;
+    private static final String PREFIX = "auth:result:";
 
     public void put(String state, String accessToken, String sessionId) {
-        results.put(state, new AuthResultData(accessToken, sessionId));
+        AuthResultData data = new AuthResultData(accessToken, sessionId);
+        redisTemplate.opsForValue().set(PREFIX + state, data, Duration.ofMinutes(1)); // TTL 1분, 프론트단에선 백그라운드 풀링 형식으로 계속 작동할 것이므로.
     }
 
     public AuthResultData get(String state) {
-        return results.remove(state);
-    }
-
-    public void consume(String state) {
-        results.remove(state);
+        AuthResultData data = redisTemplate.opsForValue().get(PREFIX + state);
+        if (data != null) redisTemplate.delete("auth:" + state);
+        return data;
     }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/global/config/redis/RedisConfig.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/config/redis/RedisConfig.java
@@ -1,0 +1,28 @@
+package org.tuna.zoopzoop.backend.global.config.redis;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.tuna.zoopzoop.backend.domain.auth.dto.AuthResultData;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, AuthResultData> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, AuthResultData> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // Key Serializer
+        template.setKeySerializer(new StringRedisSerializer());
+        // Value Serializer (JSON 직렬화)
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(AuthResultData.class));
+
+        return template;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,17 @@ spring:
         options:
           model: meta-llama/llama-4-scout-17b-16e-instruct
           temperature: 0
+  data: #RedisTemplate 등을 사용하기 위한 직접 연결용
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 6000
+  cache: #Spring Cache를 사용하기 위한 Redis
+    type: redis
+    redis:
+      time-to-live: 300000
+      cache-null-values: false
+      key-prefix:
 
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
@@ -47,7 +58,6 @@ logging:
 
 server:
   port: 8080
-
 
 app:
   seed:


### PR DESCRIPTION
## 📢 기능 설명
### 기존 코드 변경 사항
- AuthResultData를 RedisTemplate를 사용하기 위해 직렬화 했습니다. (implements Serializable)
  - Redis에 저장할 때 Byte 객체로 저장하기 위함.

- AuthResult 클래스에 TTL(주기 1분)을 도입 했습니다. (테스트 ✅)

### 추가 사항
- build.gradle에 Redis 관련 의존성을 추가 했습니다.
```
build.gradle

// Redis (Spring starter)
implementation 'org.springframework.boot:spring-boot-starter-data-redis'
```

- RedisConfig 클래스에 RedisTemplate 관련 설정을 추가 했습니다. 

- Redis 캐싱 설정도 추가했으니, 아래 예제 코드 참고하시면 사용하실 수 있습니다.
```
@Service
@RequiredArgsConstructor
public class ExampleService {

    @Cacheable(value = "users", key = "#userId")
    public User getUser(Long userId) {
        // DB 조회 후 캐싱
        return userRepository.findById(userId).orElse(null);
    }
}
```
<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] 코드 머지 이후, 로컬 환경에서 프로젝트 실행을 위해서는 로컬 환경에 Redis를 설치하셔야 합니다.
- [ ] 캐싱 관련 설정도 추가해놨으니, 캐싱 추가하실거면 참고하시기 바랍니다.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

