### PR TITLE
[Hotfix] 스페이스 목록, 멤버 목록 조회 시 id 오름차순 정렬

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/repository/MembershipRepository.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/repository/MembershipRepository.java
@@ -14,13 +14,16 @@ import java.util.Optional;
 public interface MembershipRepository extends JpaRepository<Membership, Integer> {
     boolean existsByMemberAndSpace(Member member, Space space);
 
-    Page<Membership> findAllByMemberAndAuthority(Member member, Authority authority, Pageable pageable);
-    Page<Membership> findAllByMemberAndAuthorityIsNot(Member member, Authority authority, Pageable pageable);
-    Page<Membership> findAllByMember(Member member, Pageable pageable);
+    Page<Membership> findAllByMemberAndAuthorityOrderById(Member member, Authority authority, Pageable pageable);
+    Page<Membership> findAllByMemberAndAuthorityIsNotOrderById(Member member, Authority authority, Pageable pageable);
+    Page<Membership> findAllByMemberOrderById(Member member, Pageable pageable);
 
     List<Membership> findAllByMemberAndAuthority(Member member, Authority authority);
+    List<Membership> findAllByMemberAndAuthorityOrderById(Member member, Authority authority);
     List<Membership> findAllByMemberAndAuthorityIsNot(Member member, Authority authority);
+    List<Membership> findAllByMemberAndAuthorityIsNotOrderById(Member member, Authority authority);
     List<Membership> findAllByMember(Member member);
+    List<Membership> findAllByMemberOrderById(Member member);
 
     boolean existsByMemberAndSpaceAndAuthorityIsNot(Member member, Space space, Authority authority);
 
@@ -29,8 +32,12 @@ public interface MembershipRepository extends JpaRepository<Membership, Integer>
     Optional<Membership> findByMemberAndSpace(Member member, Space space);
 
     List<Membership> findAllBySpaceAndAuthority(Space space, Authority authority);
+    List<Membership> findAllBySpaceAndAuthorityOrderById(Space space, Authority authority);
 
     List<Membership> findAllBySpaceAndAuthorityIsNot(Space space, Authority authority);
+    List<Membership> findAllBySpaceAndAuthorityIsNotOrderById(Space space, Authority authority);
 
     long countBySpaceAndAuthority(Space space, Authority authority);
+
+
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/service/MembershipService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/service/MembershipService.java
@@ -60,11 +60,11 @@ public class MembershipService {
      */
     public Page<Membership> findByMember(Member member, String state, Pageable pageable) {
         if (state.equalsIgnoreCase("PENDING")) {
-            return membershipRepository.findAllByMemberAndAuthority(member, Authority.PENDING, pageable);
+            return membershipRepository.findAllByMemberAndAuthorityOrderById(member, Authority.PENDING, pageable);
         } else if (state.equalsIgnoreCase("JOINED")) {
-            return membershipRepository.findAllByMemberAndAuthorityIsNot(member, Authority.PENDING, pageable);
+            return membershipRepository.findAllByMemberAndAuthorityIsNotOrderById(member, Authority.PENDING, pageable);
         } else {
-            return membershipRepository.findAllByMember(member, pageable);
+            return membershipRepository.findAllByMemberOrderById(member, pageable);
         }
     }
 
@@ -76,11 +76,12 @@ public class MembershipService {
      */
     public List<Membership> findByMember(Member member, String state) {
         if (state.equalsIgnoreCase("PENDING")) {
-            return membershipRepository.findAllByMemberAndAuthority(member, Authority.PENDING);
+            return membershipRepository.findAllByMemberAndAuthorityOrderById(member, Authority.PENDING);
         } else if (state.equalsIgnoreCase("JOINED")) {
-            return membershipRepository.findAllByMemberAndAuthorityIsNot(member, Authority.PENDING);
+            return membershipRepository.findAllByMemberAndAuthorityIsNotOrderById(member, Authority.PENDING);
         } else {
-            return membershipRepository.findAllByMember(member);
+            List<Membership> memberships = membershipRepository.findAllByMemberOrderById(member);
+            return memberships;
         }
     }
 
@@ -90,7 +91,7 @@ public class MembershipService {
      * @return 해당 스페이스에 속한 초대 상태(PENDING)인 멤버십 목록
      */
     public List<Membership> findInvitationsBySpace(Space space) {
-        return membershipRepository.findAllBySpaceAndAuthority(space, Authority.PENDING);
+        return membershipRepository.findAllBySpaceAndAuthorityOrderById(space, Authority.PENDING);
     }
 
     /**
@@ -99,7 +100,7 @@ public class MembershipService {
      * @return 해당 스페이스에 속한 가입 상태(JOINED)인 멤버십 목록
      */
     public List<Membership> findMembersBySpace(Space space) {
-        return membershipRepository.findAllBySpaceAndAuthorityIsNot(space, Authority.PENDING);
+        return membershipRepository.findAllBySpaceAndAuthorityIsNotOrderById(space, Authority.PENDING);
     }
 
     // ======================== 권한 조회 ======================== //


### PR DESCRIPTION
## 📢 기능 설명
- 데이터 목록 조회 시 비일관성 문제로 테스트 간헐적으로 실패
- 스페이스 목록, 멤버 목록 조회 시 항상 id 오름차순으로 정렬하도록 로직 변경
<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

