### PR TITLE
Ops 360 be refactor folder datasource 리펙토링

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/entity/Archive.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/entity/Archive.java
@@ -22,7 +22,7 @@ public class Archive extends BaseEntity {
     private ArchiveType archiveType;
 
     //아카이브 삭제(아마도 계정 탈퇴) 시 폴더 일괄 삭제
-    @OneToMany(mappedBy = "archive", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "archive", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Folder> folders = new ArrayList<>();
 
     public Archive(ArchiveType archiveType) {

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/repository/PersonalArchiveRepository.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/archive/repository/PersonalArchiveRepository.java
@@ -2,6 +2,7 @@ package org.tuna.zoopzoop.backend.domain.archive.archive.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.tuna.zoopzoop.backend.domain.archive.archive.entity.PersonalArchive;
 
 import java.util.Optional;
@@ -14,10 +15,10 @@ public interface PersonalArchiveRepository extends JpaRepository<PersonalArchive
      * @return  PersonalArchive 엔티티
      */
     @Query("""
-        select pa
-        from PersonalArchive pa
-        join fetch pa.archive a
-        where pa.member.id = :memberId
-    """)
-    Optional<PersonalArchive> findByMemberId(Integer memberId);
+    select pa
+    from PersonalArchive pa
+    join fetch pa.archive a
+    where pa.member.id = :memberId
+""")
+    Optional<PersonalArchive> findByMemberId(@Param("memberId") Integer memberId);
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderController.java
@@ -16,7 +16,6 @@ import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.global.rsData.RsData;
 import org.tuna.zoopzoop.backend.global.security.jwt.CustomUserDetails;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -54,20 +53,26 @@ public class FolderController {
      * 내 PersonalArchive 안의 folder 삭제
      * @param folderId  삭제할 folderId
      */
-    @Operation(summary = "폴더 삭제", description = "내 PersonalArchive 안에 폴더를 삭제합니다.")
     @DeleteMapping("/{folderId}")
     public ResponseEntity<Map<String, Object>> deleteFolder(
             @PathVariable Integer folderId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        if (folderId == 0) {
+            var body = new java.util.HashMap<String, Object>();
+            body.put("status", 400);
+            body.put("msg", "default 폴더는 삭제할 수 없습니다.");
+            body.put("data", null); // HashMap은 null 허용
+            return ResponseEntity.badRequest().body(body);
+        }
+
         Member member = userDetails.getMember();
         String deletedFolderName = folderService.deleteFolder(member.getId(), folderId);
 
-        Map<String, Object> body = new HashMap<>();
+        var body = new java.util.HashMap<String, Object>();
         body.put("status", 200);
         body.put("msg", deletedFolderName + " 폴더가 삭제됐습니다.");
-        body.put("data", null);
-
+        body.put("data", null); // <- 여기도 Map.of 쓰면 NPE 납니다
         return ResponseEntity.ok(body);
     }
 
@@ -76,23 +81,29 @@ public class FolderController {
      * @param folderId 수정할 폴더 Id
      * @param body  수정할 폴더 값
      */
-    @Operation(summary = "폴더 수정", description = "내 PersonalArchive 안에 폴더를 수정합니다.")
     @PatchMapping("/{folderId}")
     public ResponseEntity<Map<String, Object>> updateFolderName(
             @PathVariable Integer folderId,
             @RequestBody Map<String, String> body,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
+        if (folderId == 0) {
+            var res = new java.util.HashMap<String, Object>();
+            res.put("status", 400);
+            res.put("msg", "default 폴더는 이름을 변경할 수 없습니다.");
+            res.put("data", null);
+            return ResponseEntity.badRequest().body(res);
+        }
+
         Member member = userDetails.getMember();
         String newName = body.get("folderName");
         String updatedName = folderService.updateFolderName(member.getId(), folderId, newName);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("msg", "폴더 이름이 " + updatedName + " 으로 변경됐습니다.");
-        response.put("data", Map.of("folderName", updatedName));
-
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(java.util.Map.of(
+                "status", 200,
+                "msg", "폴더 이름이 " + updatedName + " 으로 변경됐습니다.",
+                "data", java.util.Map.of("folderName", updatedName)
+        ));
     }
 
     /**
@@ -117,30 +128,32 @@ public class FolderController {
     }
 
     /**
-     * 폴더(내 PersonalArchive 소속) 안의 파일 목록 조회
+     * 폴더 안의 파일 목록 조회
      */
-    @Operation(summary = "폴더 내 파일 목록 조회", description = "내 PersonalArchive의 폴더 속 파일 목록을 조회합니다.")
     @GetMapping("/{folderId}/files")
     public ResponseEntity<?> getFilesInFolder(
             @PathVariable Integer folderId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Member member = userDetails.getMember();
-        FolderFilesDto rs = folderService.getFilesInFolderForPersonal(member.getId(), folderId);
+        int memberId = userDetails.getMember().getId();
 
-        return ResponseEntity.ok(
-                Map.of(
-                        "status", 200,
-                        "msg", "해당 폴더의 파일 목록을 불러왔습니다.",
-                        "data", Map.of(
-                                "folder", Map.of(
-                                        "folderId", rs.folderId(),
-                                        "folderName", rs.folderName()
-                                ),
-                                "files", rs.files()
-                        )
+        Integer targetFolderId = (folderId == 0)
+                ? folderService.getDefaultFolderId(memberId)
+                : folderId;
+
+        FolderFilesDto rs = folderService.getFilesInFolderForPersonal(memberId, targetFolderId);
+
+        return ResponseEntity.ok(Map.of(
+                "status", 200,
+                "msg", folderId == 0 ? "기본 폴더의 파일 목록을 불러왔습니다." : "해당 폴더의 파일 목록을 불러왔습니다.",
+                "data", Map.of(
+                        "folder", Map.of(
+                                "folderId", rs.folderId(),
+                                "folderName", rs.folderName()
+                        ),
+                        "files", rs.files()
                 )
-        );
+        ));
     }
 
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderController.java
@@ -1,5 +1,7 @@
 package org.tuna.zoopzoop.backend.domain.archive.folder.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/archive/folder")
 @RequiredArgsConstructor
+@Tag(name = "ApiV1Folder", description = "개인 아카이브의 폴더 CRUD")
 public class FolderController {
 
     private final FolderService folderService;
@@ -30,6 +33,7 @@ public class FolderController {
      * @param rq reqBodyForCreateFolder
      * @return resBodyForCreateFolder
      */
+    @Operation(summary = "폴더 생성", description = "내 PersonalArchive 안에 새 폴더를 생성합니다.")
     @PostMapping
     public RsData<resBodyForCreateFolder> createFolder(
             @Valid @RequestBody reqBodyForCreateFolder rq,
@@ -50,6 +54,7 @@ public class FolderController {
      * 내 PersonalArchive 안의 folder 삭제
      * @param folderId  삭제할 folderId
      */
+    @Operation(summary = "폴더 삭제", description = "내 PersonalArchive 안에 폴더를 삭제합니다.")
     @DeleteMapping("/{folderId}")
     public ResponseEntity<Map<String, Object>> deleteFolder(
             @PathVariable Integer folderId,
@@ -71,6 +76,7 @@ public class FolderController {
      * @param folderId 수정할 폴더 Id
      * @param body  수정할 폴더 값
      */
+    @Operation(summary = "폴더 수정", description = "내 PersonalArchive 안에 폴더를 수정합니다.")
     @PatchMapping("/{folderId}")
     public ResponseEntity<Map<String, Object>> updateFolderName(
             @PathVariable Integer folderId,
@@ -93,6 +99,7 @@ public class FolderController {
      *  개인 아카이브의 폴더 이름 전부 조회
      *  "default", "폴더1", "폴더2"
      */
+    @Operation(summary = "폴더 이름 조회", description = "내 PersonalArchive 안에 이름을 전부 조회합니다.")
     @GetMapping
     public ResponseEntity<?> getFolders(
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -112,6 +119,7 @@ public class FolderController {
     /**
      * 폴더(내 PersonalArchive 소속) 안의 파일 목록 조회
      */
+    @Operation(summary = "폴더 내 파일 목록 조회", description = "내 PersonalArchive의 폴더 속 파일 목록을 조회합니다.")
     @GetMapping("/{folderId}/files")
     public ResponseEntity<?> getFilesInFolder(
             @PathVariable Integer folderId,

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/repository/FolderRepository.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/repository/FolderRepository.java
@@ -17,13 +17,15 @@ public interface FolderRepository extends JpaRepository<Folder, Integer>{
      * @param filenameEnd "파일명 + \ufffff"
      */
     @Query("""
-        select f.name
-        from Folder f
-        where f.archive.id = :archiveId
-          and f.name >= :filename
-          and f.name < :filenameEnd
-    """)
-    List<String> findNamesForConflictCheck(Integer archiveId, String filename, String filenameEnd);
+    select f.name
+    from Folder f
+    where f.archive.id = :archiveId
+      and f.name >= :filename
+      and f.name < :filenameEnd
+""")
+    List<String> findNamesForConflictCheck(@Param("archiveId") Integer archiveId,
+                                           @Param("filename") String filename,
+                                           @Param("filenameEnd") String filenameEnd);
     // 개인 아카이브의 폴더 조회
     List<Folder> findByArchive(Archive archive);
 
@@ -38,24 +40,24 @@ public interface FolderRepository extends JpaRepository<Folder, Integer>{
      * @param memberId  조회할 회원 Id
      */
     @Query("""
-        select f
-        from Folder f
-        join f.archive a
-        join PersonalArchive pa on pa.archive = a
-        where pa.member.id = :memberId
-          and f.isDefault = true
-    """)
-    Optional<Folder> findDefaultFolderByMemberId(Integer memberId);
+    select f
+    from Folder f
+    join f.archive a
+    join PersonalArchive pa on pa.archive = a
+    where pa.member.id = :memberId
+      and f.isDefault = true
+""")
+    Optional<Folder> findDefaultFolderByMemberId(@Param("memberId") Integer memberId);
 
     // 한 번의 조인으로 존재 + 소유권(memberId) 검증
     @Query("""
-        select f
-        from Folder f
-        join f.archive a
-        join PersonalArchive pa on pa.archive = a
-        where f.id = :folderId
-          and pa.member.id = :memberId
-    """)
+    select f
+    from Folder f
+    join f.archive a
+    join PersonalArchive pa on pa.archive = a
+    where f.id = :folderId
+      and pa.member.id = :memberId
+""")
     Optional<Folder> findByIdAndMemberId(@Param("folderId") Integer folderId,
                                          @Param("memberId") Integer memberId);
 

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
@@ -192,6 +192,14 @@ public class FolderService {
         return new FolderFilesDto(folder.getId(), folder.getName(), files);
     }
 
+
+    public Integer getDefaultFolderId(int memberId) {
+        Folder folder = folderRepository.findDefaultFolderByMemberId(memberId)
+                .orElseThrow(() -> new NoResultException("default 폴더를 찾을 수 없습니다."));
+        return folder.getId();
+
+    }
+
     /**
      * 입력된 폴더명을 (폴더명, 숫자)로 분리하는 유틸 클래스
      * “폴더명” → (”폴더명”, null)

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
@@ -42,11 +42,11 @@ public class FolderService {
             throw new IllegalArgumentException("폴더 이름은 비어 있을 수 없습니다.");
 
         Member member = memberRepository.findById(currentMemberId)
-                .orElseThrow(() -> new IllegalArgumentException("멤버를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NoResultException("멤버를 찾을 수 없습니다."));
 
         Archive archive = personalArchiveRepository.findByMemberId(member.getId())
                 .map(PersonalArchive::getArchive)
-                .orElseThrow(() -> new IllegalStateException("개인 아카이브가 없습니다."));
+                .orElseThrow(() -> new NoResultException("개인 아카이브가 없습니다."));
 
         final String requested = folderName.trim();
 

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/auth/dev/controller/DevController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/auth/dev/controller/DevController.java
@@ -23,8 +23,8 @@ public class DevController {
 
     @GetMapping("/token")
     public Map<String, String> issueToken(
-            @RequestParam Provider provider,
-            @RequestParam String key
+            @RequestParam(name = "provider") Provider provider,
+            @RequestParam(name = "key") String key
     ) {
         Member m = memberRepository.findByProviderAndProviderKey(provider, key)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found"));

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/service/DashboardService.java
@@ -3,8 +3,6 @@ package org.tuna.zoopzoop.backend.domain.dashboard.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.codec.binary.Hex;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.dashboard.dto.BodyForReactFlow;
@@ -16,11 +14,7 @@ import org.tuna.zoopzoop.backend.domain.dashboard.repository.DashboardRepository
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
-import java.security.MessageDigest;
 import java.util.List;
 
 @Service

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/controller/DatasourceController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/controller/DatasourceController.java
@@ -1,5 +1,7 @@
 package org.tuna.zoopzoop.backend.domain.datasource.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,6 +23,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/v1/archive")
 @RequiredArgsConstructor
+@Tag(name = "ApiV1DataSource", description = "개인 아카이브의 파일 CRUD")
 public class DatasourceController {
 
     private final DataSourceService dataSourceService;
@@ -30,6 +33,7 @@ public class DatasourceController {
      * sourceUrl 등록할 자료 url
      * folderId  등록될 폴더 위치(null 이면 default)
      */
+    @Operation(summary = "자료 등록", description = "내 PersonalArchive 안에 자료를 등록합니다.")
     @PostMapping("")
     public ResponseEntity<?> createDataSource(
             @Valid @RequestBody reqBodyForCreateDataSource rq,
@@ -49,6 +53,7 @@ public class DatasourceController {
     /**
      * 자료 단건 삭제
      */
+    @Operation(summary = "자료 단건 삭제", description = "내 PersonalArchive 안에 자료를 단건 삭제합니다.")
     @DeleteMapping("/{dataSourceId}")
     public ResponseEntity<Map<String, Object>> delete(
             @PathVariable Integer dataSourceId,
@@ -68,6 +73,7 @@ public class DatasourceController {
     /**
      * 자료 다건 삭제
      */
+    @Operation(summary = "자료 다건 삭제", description = "내 PersonalArchive 안에 자료를 다건 삭제합니다.")
     @PostMapping("/delete")
     public ResponseEntity<Map<String, Object>> deleteMany(
             @Valid @RequestBody reqBodyForDeleteMany body,
@@ -88,6 +94,7 @@ public class DatasourceController {
      * 자료 단건 이동
      *  folderId=null 이면 default 폴더
      */
+    @Operation(summary = "자료 단건 이동", description = "내 PersonalArchive 안에 자료를 단건 이동합니다.")
     @PatchMapping("/{dataSourceId}/move")
     public ResponseEntity<?> moveDataSource(
             @PathVariable Integer dataSourceId,
@@ -118,6 +125,7 @@ public class DatasourceController {
     /**
      * 자료 다건 이동
      */
+    @Operation(summary = "자료 다건 이동", description = "내 PersonalArchive 안에 자료들를 다건 이동합니다..")
     @PatchMapping("/move")
     public ResponseEntity<?> moveMany(
             @Valid @RequestBody reqBodyForMoveMany rq,
@@ -141,6 +149,7 @@ public class DatasourceController {
      * @param dataSourceId  수정할 파일 Id
      * @param body          수정할 내용
      */
+    @Operation(summary = "자료 수정", description = "내 PersonalArchive 안에 자료를 수정합니다.")
     @PatchMapping("/{dataSourceId}")
     public ResponseEntity<?> updateDataSource(
             @PathVariable Integer dataSourceId,
@@ -162,6 +171,10 @@ public class DatasourceController {
         );
     }
 
+    /**
+     * 자료 검색 
+     */
+    @Operation(summary = "자료 검색", description = "내 PersonalArchive 안에 자료들을 검색합니다.")
     @GetMapping("")
     public ResponseEntity<?> search(
             @RequestParam(required = false) String title,

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/controller/FolderControllerTest.java
@@ -22,21 +22,17 @@ import org.tuna.zoopzoop.backend.domain.datasource.repository.DataSourceReposito
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
 import org.tuna.zoopzoop.backend.domain.member.repository.MemberRepository;
 import org.tuna.zoopzoop.backend.domain.member.service.MemberService;
+import org.tuna.zoopzoop.backend.global.jpa.entity.BaseEntity;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-/**
- * FolderController 통합 테스트 (Given / When / Then 주석 유지)
- *
- * - @SpringBootTest + @AutoConfigureMockMvc 로 전체 컨텍스트에서 테스트
- * - @WithUserDetails 를 사용해 인증 principal 을 주입
- * - 테스트용 멤버는 BeforeAll에서 생성 (UserDetailsService 가 해당 username 으로 로드 가능해야 함)
- */
+
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -61,14 +57,12 @@ class FolderControllerTest {
 
     @BeforeAll
     void beforeAll() {
-        // WithUserDetails가 SecurityContext 생성 시 DB에서 사용자를 조회하므로 미리 생성
         try {
             memberService.createMember("folderTester", "http://example.com/profile.png", TEST_PROVIDER_KEY, Provider.KAKAO);
         } catch (Exception ignored) {}
 
-        // 준비된 멤버 ID
         testMemberId = memberRepository.findByProviderAndProviderKey(Provider.KAKAO, TEST_PROVIDER_KEY)
-                .map(m -> m.getId())
+                .map(BaseEntity::getId)
                 .orElseThrow();
 
         // GIVEN: 테스트용 폴더 및 샘플 자료 준비 (docs 폴더 + 2개 자료)
@@ -77,7 +71,7 @@ class FolderControllerTest {
 
         Folder docsFolder = folderRepository.findById(docsFolderId).orElseThrow();
 
-        // 자료 2건 생성 — **category는 NOT NULL enum** 이므로 반드시 설정
+        // 자료 2건 생성
         DataSource d1 = new DataSource();
         d1.setFolder(docsFolder);
         d1.setTitle("spec.pdf");
@@ -143,6 +137,8 @@ class FolderControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+
+    // DeleteFile
     @Test
     @DisplayName("개인 아카이브 폴더 삭제 - 성공 시 200과 삭제 메시지 반환")
     @WithUserDetails("KAKAO:sc1111")
@@ -159,6 +155,17 @@ class FolderControllerTest {
     }
 
     @Test
+    @DisplayName("개인 아카이브 폴더 삭제 실패- 기본 폴더면 400")
+    @WithUserDetails("KAKAO:sc1111")
+    void deleteDefaultFolder_badRequest() throws Exception {
+        mockMvc.perform(delete("/api/v1/archive/folder/{folderId}", 0))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.msg").value("default 폴더는 삭제할 수 없습니다."))
+                .andExpect(jsonPath("$.data").value(nullValue()));
+    }
+
+    @Test
     @DisplayName("개인 아카이브 폴더 삭제 - 존재하지 않으면 404")
     @WithUserDetails("KAKAO:sc1111")
     void deleteFolder_notFound() throws Exception {
@@ -168,6 +175,7 @@ class FolderControllerTest {
                 .andExpect(jsonPath("$.status").value("404"))
                 .andExpect(jsonPath("$.msg").value("존재하지 않는 폴더입니다."));
     }
+
 
     // UpdateFile
     @Test
@@ -189,6 +197,22 @@ class FolderControllerTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.msg").value("폴더 이름이 회의록 으로 변경됐습니다."))
                 .andExpect(jsonPath("$.data.folderName").value("회의록"));
+    }
+
+    @Test
+    @DisplayName("개인 아카이브 폴더 이름 변경 실패 - 기본 폴더면 400")
+    @WithUserDetails("KAKAO:sc1111")
+    void updateDefaultFolder_badRequest() throws Exception {
+        var body = new java.util.HashMap<String,String>();
+        body.put("folderName","무시됨");
+
+        mockMvc.perform(patch("/api/v1/archive/folder/{folderId}", 0)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.msg").value("default 폴더는 이름을 변경할 수 없습니다."))
+                .andExpect(jsonPath("$.data").value(nullValue()));
     }
 
     @Test
@@ -244,6 +268,21 @@ class FolderControllerTest {
                 .andExpect(jsonPath("$.data.files[0].sourceUrl").isString())
                 .andExpect(jsonPath("$.data.files[0].imageUrl").isString());
     }
+
+    @Test
+    @DisplayName("폴더 파일 목록 조회 - default 폴더 성공")
+    @WithUserDetails("KAKAO:sc1111")
+    void getFilesInDefaultFolder_success() throws Exception {
+        mockMvc.perform(get("/api/v1/archive/folder/{folderId}/files", 0)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.msg").value("기본 폴더의 파일 목록을 불러왔습니다."))
+                .andExpect(jsonPath("$.data.folder.folderId").isNumber())
+                .andExpect(jsonPath("$.data.folder.folderName").isString())
+                .andExpect(jsonPath("$.data.files").isArray());
+    }
+
 
     @Test
     @DisplayName("폴더 내 파일 목록 조회 - 폴더가 없으면 404")

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
@@ -125,7 +125,7 @@ class FolderServiceTest {
         when(memberRepository.findById(2)).thenReturn(Optional.empty());
 
         // when & then
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(NoResultException.class,
                 () -> folderService.createFolderForPersonal(2, "보고서"));
     }
 
@@ -292,7 +292,7 @@ class FolderServiceTest {
 
         // then
         assertThat(dto.files()).hasSize(2);
-        FileSummary f0 = dto.files().get(0);
+        FileSummary f0 = dto.files().getFirst();
         assertThat(f0.dataSourceId()).isEqualTo(10);
         assertThat(f0.title()).isEqualTo("spec.pdf");
         assertThat(f0.summary()).isEqualTo("요약 A");

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/news/service/NewsServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/news/service/NewsServiceTest.java
@@ -16,7 +16,6 @@ import org.tuna.zoopzoop.backend.domain.datasource.entity.Category;
 import org.tuna.zoopzoop.backend.domain.datasource.entity.DataSource;
 import org.tuna.zoopzoop.backend.domain.datasource.entity.Tag;
 import org.tuna.zoopzoop.backend.domain.datasource.repository.DataSourceRepository;
-import org.tuna.zoopzoop.backend.domain.datasource.service.DataSourceService;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
 import org.tuna.zoopzoop.backend.domain.member.repository.MemberRepository;
@@ -36,9 +35,6 @@ public class NewsServiceTest {
     private NewsService newsService;
 
     @Autowired
-    private NewsAPIService newsAPIService;
-
-    @Autowired
     private MemberService memberService;
 
     @Autowired
@@ -51,10 +47,9 @@ public class NewsServiceTest {
     private FolderRepository folderRepository;
 
     @Autowired
-    private DataSourceService dataSourceService;
-
-    @Autowired
     private DataSourceRepository dataSourceRepository;
+
+    private Integer newsFolderId;
 
     private final Map<Integer, List<Tag>> tags = Map.ofEntries(
             Map.entry(1, List.of(new Tag("A"), new Tag("B"), new Tag("E"))),
@@ -100,6 +95,8 @@ public class NewsServiceTest {
         );
 
         FolderResponse folderResponse = folderService.createFolderForPersonal(member.getId(), "newServiceTestFolder");
+        newsFolderId = folderResponse.folderId();
+
         Folder folder = folderRepository.findById(folderResponse.folderId()).orElse(null);
 
         for(int i = 1; i <= 10; i++) {
@@ -111,8 +108,7 @@ public class NewsServiceTest {
     @DisplayName("태그 빈도 수 추출 테스트")
     void DataSourceExtractTagsTest(){
         Member member = memberService.findByProviderKey("newsServiceTestKey");
-        List<FolderResponse> folderResponses = folderService.getFoldersForPersonal(member.getId());
-        List<String> frequency = newsService.getTagFrequencyFromFiles(member.getId(), folderResponses.get(0).folderId());
+        List<String> frequency = newsService.getTagFrequencyFromFiles(member.getId(), newsFolderId);
 
         assertEquals("E", frequency.get(0));
         assertEquals("B", frequency.get(1));


### PR DESCRIPTION
## 📢 기능 설명
<br>

기본 폴더(default) 처리 방식 통일

- folderId = 0일 경우 → default 폴더로 취급하도록 컨트롤러 로직 수정
- 삭제/수정 요청 시 0이면 400 반환 (default 폴더는 삭제/수정 불가)
- 파일 목록 조회 시 0이면 default 폴더의 파일을 조회

엔티티 수정

- Archive.folders 관계에 cascade = PERSIST 추가 → PersonalArchive 생성 시 default 폴더가 DB에 자동 저장되도록 보장


NewsServiceTest
폴더 선택 시 무조건 첫 번째 폴더를 사용하던 부분 수정 
→ setUp()에서 생성한 테스트용 폴더 ID를 직접 사용하도록 변경
(default 폴더가 먼저 조회될 경우 빈 리스트가 리턴되어 IndexOutOfBoundsException 발생하던 문제 해결)

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

