### PR TITLE
[fix/OPS-346] 파일 조회 수정

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderService.java
@@ -16,6 +16,7 @@ import org.tuna.zoopzoop.backend.domain.datasource.dto.FolderFilesDto;
 import org.tuna.zoopzoop.backend.domain.datasource.repository.DataSourceRepository;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.domain.member.repository.MemberRepository;
+import org.tuna.zoopzoop.backend.domain.datasource.entity.Tag;
 
 import java.util.HashSet;
 import java.util.List;
@@ -184,8 +185,11 @@ public class FolderService {
                         ds.getSummary(),
                         ds.getSourceUrl(),
                         ds.getImageUrl(),
-                        ds.getTags() == null ? List.of() : ds.getTags(),
-                        ds.getCategory() == null ? null : ds.getCategory().toString()
+                        ds.getTags() == null ? List.of()
+                                : ds.getTags().stream()
+                                .map(Tag::getTagName)
+                                .toList(),
+                        ds.getCategory() == null ? null : ds.getCategory().name()
                 ))
                 .toList();
 

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/dto/FileSummary.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/dto/FileSummary.java
@@ -1,7 +1,5 @@
 package org.tuna.zoopzoop.backend.domain.datasource.dto;
 
-import org.tuna.zoopzoop.backend.domain.datasource.entity.Tag;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -12,6 +10,8 @@ public record FileSummary(
         String summary,
         String sourceUrl,
         String imageUrl,
-        List<Tag> tags,
+        List<String> tags,
         String category
 ) {}
+
+

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/news/service/NewsService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/news/service/NewsService.java
@@ -22,8 +22,10 @@ public class NewsService {
         List<FileSummary> files = folderFilesDto.files();
 
         Map<String, Long> tags = files.stream()
-                .flatMap(file -> file.tags().stream())
-                .map(tag -> tag.getTagName())
+                .flatMap(file -> {
+                    List<String> ts = file.tags();
+                    return (ts == null ? List.<String>of() : ts).stream();
+                })
                 .collect(Collectors.groupingBy(
                         tagName -> tagName,
                         Collectors.counting()

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/archive/folder/service/FolderServiceTest.java
@@ -298,7 +298,7 @@ class FolderServiceTest {
         assertThat(f0.summary()).isEqualTo("요약 A");
         assertThat(f0.sourceUrl()).isEqualTo("http://src/a");
         assertThat(f0.imageUrl()).isEqualTo("http://img/a");
-        assertThat(f0.tags()).extracting(Tag::getTagName).containsExactly("tag1", "tag2");
+        assertThat(f0.tags()).containsExactly("tag1", "tag2");
     }
 
     @Test

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceControllerTest.java
@@ -8,7 +8,6 @@ import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
 import org.tuna.zoopzoop.backend.domain.member.service.MemberService;


### PR DESCRIPTION
## 📢 기능 설명
<br>
수정 내용

- GET /api/v1/archive/folder/{folderId}/files 호출 시 경로 불일치로 500 에러 발생하던 문제 수정
- FileSummary DTO에서 List<Tag> → List<String>으로 수정하여 JSON 직렬화 오류 해결
- NewsService에서 태그 빈도 계산 시 getTagName() 대신 문자열 그대로 처리하도록 변경

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

