### PR TITLE
Ops 373 be refactor 자료 조회 검색 요구사항 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
     // OpenAPI / Swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
+    // OpenAPI - nullable support
+    implementation "org.openapitools:jackson-databind-nullable:0.2.6"
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/dto/reqBodyForUpdateDataSource.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/dto/reqBodyForUpdateDataSource.java
@@ -1,8 +1,13 @@
 package org.tuna.zoopzoop.backend.domain.datasource.dto;
 
-import jakarta.validation.constraints.NotNull;
+import java.util.List;
 
 public record reqBodyForUpdateDataSource(
-        @NotNull String title,
-        @NotNull String summary
+        String title,
+        String summary,
+        String sourceUrl,
+        String imageUrl,
+        String source,
+        List<String> tags,
+        String category
 ) {}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/dto/reqBodyForUpdateDataSource.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/dto/reqBodyForUpdateDataSource.java
@@ -1,13 +1,13 @@
 package org.tuna.zoopzoop.backend.domain.datasource.dto;
 
-import java.util.List;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 public record reqBodyForUpdateDataSource(
-        String title,
-        String summary,
-        String sourceUrl,
-        String imageUrl,
-        String source,
-        List<String> tags,
-        String category
+        JsonNullable<String> title,
+        JsonNullable<String> summary,
+        JsonNullable<String> sourceUrl,
+        JsonNullable<String> imageUrl,
+        JsonNullable<String> source,
+        JsonNullable<java.util.List<String>> tags,
+        JsonNullable<String> category
 ) {}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/entity/DataSource.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/datasource/entity/DataSource.java
@@ -15,17 +15,6 @@ import java.util.List;
 @Setter
 @Entity
 @NoArgsConstructor
-@Table(
-        uniqueConstraints = {
-                // 복합 Unique 제약(folder_id, title)
-                // 같은 폴더 내에 자료 제목 중복 금지
-                @UniqueConstraint(columnNames = {"folder_id", "title"})
-        },
-        // 폴더 내 자료 목록 조회 최적화
-        indexes = {
-                @Index(name = "idx_datasource__folder_id", columnList = "folder_id")
-        }
-)
 public class DataSource extends BaseEntity {
     //연결된 폴더 id
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -33,20 +22,20 @@ public class DataSource extends BaseEntity {
     private Folder folder;
 
     //제목
-    @Column(nullable = false)
+    @Column
     private String title;
 
     //요약
-    @Column(nullable = false)
+    @Column
     private String summary;
 
     //소스 데이터의 작성일자
     //DB 저장용 createdDate와 다름.
-    @Column(nullable = false)
+    @Column
     private LocalDate dataCreatedDate;
 
     //소스 데이터 URL
-    @Column(nullable = false)
+    @Column
     private String sourceUrl;
 
     //썸네일 이미지 URL
@@ -54,6 +43,7 @@ public class DataSource extends BaseEntity {
     private String imageUrl;
 
     // 자료 출처 (동아일보, Tstory 등등)
+    @Column
     private String source;
 
     // 태그 목록
@@ -62,11 +52,11 @@ public class DataSource extends BaseEntity {
 
     // 카테고리 목록
     @Enumerated(EnumType.STRING) // IT, SCIENCE 등 ENUM 이름으로 저장
-    @Column(nullable = false)
+    @Column
     private Category category;
 
     // 활성화 여부
-    @Column(nullable = false)
+    @Column
     private boolean isActive = true;
 
     // 삭제 일자

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/controller/DatasourceControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/datasource/controller/DatasourceControllerTest.java
@@ -3,6 +3,7 @@ package org.tuna.zoopzoop.backend.domain.datasource.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,10 +18,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.archive.folder.dto.FolderResponse;
 import org.tuna.zoopzoop.backend.domain.archive.folder.entity.Folder;
-import org.tuna.zoopzoop.backend.domain.archive.folder.service.FolderService;
 import org.tuna.zoopzoop.backend.domain.archive.folder.repository.FolderRepository;
+import org.tuna.zoopzoop.backend.domain.archive.folder.service.FolderService;
 import org.tuna.zoopzoop.backend.domain.datasource.dataprocessor.service.DataProcessorService;
-import org.tuna.zoopzoop.backend.domain.datasource.dto.*;
+import org.tuna.zoopzoop.backend.domain.datasource.dto.DataSourceDto;
+import org.tuna.zoopzoop.backend.domain.datasource.dto.reqBodyForCreateDataSource;
+import org.tuna.zoopzoop.backend.domain.datasource.dto.reqBodyForDeleteMany;
+import org.tuna.zoopzoop.backend.domain.datasource.dto.reqBodyForMoveDataSource;
 import org.tuna.zoopzoop.backend.domain.datasource.entity.Category;
 import org.tuna.zoopzoop.backend.domain.datasource.entity.DataSource;
 import org.tuna.zoopzoop.backend.domain.datasource.entity.Tag;
@@ -37,9 +41,8 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -94,6 +97,11 @@ class DatasourceControllerTest {
                     .thenReturn(java.util.List.of("AI", "Spring"));
 
             return mock;
+        }
+
+        @Bean
+         com.fasterxml.jackson.databind.Module jsonNullableModule() {
+            return new JsonNullableModule();
         }
     }
 
@@ -501,21 +509,20 @@ class DatasourceControllerTest {
 
 
     @Test
-    @DisplayName("자료 수정 실패: sourceUrl가 빈 문자열 → 400")
+    @DisplayName("자료 수정 성공: sourceUrl가 빈문자여도 허용 → 200")
     @WithUserDetails(value = "KAKAO:testUser_sc1111", setupBefore = TestExecutionEvent.TEST_METHOD)
-    void update_badRequest_sourceUrl_blank() throws Exception {
+    void update_ok_sourceUrl_blank_allowed() throws Exception {
         String body = updateJson(null, null, "  ", null, null, null, null);
 
         mockMvc.perform(patch("/api/v1/archive/{dataSourceId}", dataSourceId1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.msg").exists());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
     }
 
     @Test
-    @DisplayName("자료 수정 실패: 모든 필드 미전달(null) → 400")
+    @DisplayName("자료 수정 실패: 모든 필드 미전달 → 400")
     @WithUserDetails(value = "KAKAO:testUser_sc1111", setupBefore = TestExecutionEvent.TEST_METHOD)
     void update_badRequest_all_null() throws Exception {
         // 빈 JSON 객체 {}


### PR DESCRIPTION
## 📢 기능 설명
<br>
자료 수정 API 개선

- PATCH /api/v1/archive/{dataSourceId}
- 요청 Body의 모든 필드(title, summary, sourceUrl, imageUrl, source, tags, category)에 대해 null 입력을 허용하도록 수정
- “필드 누락(not present)”과 “명시적 null(present but null)”을 구분
누락 → 해당 필드 변경 없음
명시적 null → DB에 null 저장 (기존 값 덮어씀)

엔티티 변경
- DataSource 엔티티 title의 unique 속성 제거
- DataSource 엔티티 컬럼들의 nullable=false 제거 (title, summary, sourceUrl, dataCreatedDate, category, isActive → nullable=true)

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

