### PR TITLE
[Feat/OPS-376] 스페이스 목록 참여 인원 반환 api 구성

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteController.java
@@ -10,7 +10,7 @@ import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceInviteList;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceSave;
-import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceMembershipInfoWithoutAuthority;
+import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInfoWithoutAuthority;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
 import org.tuna.zoopzoop.backend.global.rsData.RsData;
 import org.tuna.zoopzoop.backend.global.security.jwt.CustomUserDetails;
@@ -81,8 +81,8 @@ public class ApiV1InviteController {
 
         // 멤버십(초대) 목록 조회
         List<Membership> invitations = membershipService.findByMember(member, "PENDING");
-        List<SpaceMembershipInfoWithoutAuthority> invitationInfos = invitations.stream()
-                .map(membership -> new SpaceMembershipInfoWithoutAuthority(
+        List<SpaceInfoWithoutAuthority> invitationInfos = invitations.stream()
+                .map(membership -> new SpaceInfoWithoutAuthority(
                         membership.getSpace().getId(),
                         membership.getSpace().getName(),
                         membership.getSpace().getThumbnailUrl()

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceController.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+import org.tuna.zoopzoop.backend.domain.space.membership.dto.etc.SpaceMemberInfo;
 import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
 import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.enums.JoinState;
@@ -27,6 +28,8 @@ import org.tuna.zoopzoop.backend.global.rsData.RsData;
 import org.tuna.zoopzoop.backend.global.security.jwt.CustomUserDetails;
 
 import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/space")
@@ -126,6 +129,7 @@ public class ApiV1SpaceController {
     public RsData<ResBodyForSpaceListPage> getAllSpaces(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(required = false) JoinState state,
+            @RequestParam(defaultValue = "false") boolean includeMembers,
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         // 현재 로그인한 사용자 정보 가져오기
@@ -136,13 +140,32 @@ public class ApiV1SpaceController {
         Page<Membership> membershipsPage = membershipService.findByMember(member, stateStr, pageable);
 
         // Page<Membership>를 Page<SpaceMembershipInfo>로 변환
-        // Page 객체의 map() 메서드를 사용하면 페이징 정보는 그대로 유지하면서 내용물만 쉽게 바꿀 수 있습니다.
-        Page<SpaceInfo> spaceInfosPage = membershipsPage.map(membership -> new SpaceInfo(
-                membership.getSpace().getId(),
-                membership.getSpace().getName(),
-                membership.getSpace().getThumbnailUrl(),
-                membership.getAuthority()
-        ));
+        Page<SpaceInfo> spaceInfosPage = membershipsPage.map(membership -> {
+            Space space = membership.getSpace();
+            List<SpaceMemberInfo> memberInfos = null;
+
+            if (includeMembers) {
+                // 스페이스에 속한 멤버 목록 조회 (가입 상태만)
+                List<Membership> spaceMemberships = membershipService.findMembersBySpace(space);
+                // 멤버 목록을 DTO로 변환
+                memberInfos = spaceMemberships.stream()
+                        .map(spaceMembership -> new SpaceMemberInfo(
+                                spaceMembership.getMember().getId(),
+                                spaceMembership.getMember().getName(),
+                                spaceMembership.getMember().getProfileImageUrl(),
+                                spaceMembership.getAuthority()
+                        ))
+                        .collect(Collectors.toList());
+            }
+
+            return new SpaceInfo(
+                    space.getId(),
+                    space.getName(),
+                    space.getThumbnailUrl(),
+                    membership.getAuthority(),
+                    memberInfos // 조회된 멤버 목록 (null일 수도 있음)
+            );
+        });
 
         // 새로운 응답 DTO 생성
         ResBodyForSpaceListPage resBody = new ResBodyForSpaceListPage(spaceInfosPage);

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceController.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
@@ -19,8 +18,7 @@ import org.tuna.zoopzoop.backend.domain.space.membership.enums.JoinState;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.req.ReqBodyForSpaceSave;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceInfo;
-import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceList;
-import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceMembershipInfo;
+import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInfo;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceListPage;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceSave;
 import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
@@ -29,9 +27,6 @@ import org.tuna.zoopzoop.backend.global.rsData.RsData;
 import org.tuna.zoopzoop.backend.global.security.jwt.CustomUserDetails;
 
 import java.nio.file.AccessDeniedException;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/space")
@@ -142,7 +137,7 @@ public class ApiV1SpaceController {
 
         // Page<Membership>를 Page<SpaceMembershipInfo>로 변환
         // Page 객체의 map() 메서드를 사용하면 페이징 정보는 그대로 유지하면서 내용물만 쉽게 바꿀 수 있습니다.
-        Page<SpaceMembershipInfo> spaceInfosPage = membershipsPage.map(membership -> new SpaceMembershipInfo(
+        Page<SpaceInfo> spaceInfosPage = membershipsPage.map(membership -> new SpaceInfo(
                 membership.getSpace().getId(),
                 membership.getSpace().getName(),
                 membership.getSpace().getThumbnailUrl(),

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInfo.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInfo.java
@@ -2,7 +2,7 @@ package org.tuna.zoopzoop.backend.domain.space.space.dto.etc;
 
 import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 
-public record SpaceMembershipInfo(
+public record SpaceInfo(
         Integer id,
         String name,
         String thumbnailUrl,

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInfo.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInfo.java
@@ -1,11 +1,20 @@
 package org.tuna.zoopzoop.backend.domain.space.space.dto.etc;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.tuna.zoopzoop.backend.domain.space.membership.dto.etc.SpaceMemberInfo;
 import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SpaceInfo(
         Integer id,
         String name,
         String thumbnailUrl,
-        Authority authority
+        Authority authority,
+        List<SpaceMemberInfo> members
 ) {
+    public SpaceInfo(Integer id, String name, String thumbnailUrl, Authority authority) {
+        this(id, name, thumbnailUrl, authority, null);
+    }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInfoWithoutAuthority.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInfoWithoutAuthority.java
@@ -1,6 +1,6 @@
 package org.tuna.zoopzoop.backend.domain.space.space.dto.etc;
 
-public record SpaceMembershipInfoWithoutAuthority(
+public record SpaceInfoWithoutAuthority(
         Integer id,
         String name,
         String thumbnailUrl

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceInviteList.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceInviteList.java
@@ -1,10 +1,10 @@
 package org.tuna.zoopzoop.backend.domain.space.space.dto.res;
 
-import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceMembershipInfoWithoutAuthority;
+import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInfoWithoutAuthority;
 
 import java.util.List;
 
 public record ResBodyForSpaceInviteList(
-        List<SpaceMembershipInfoWithoutAuthority> spaces
+        List<SpaceInfoWithoutAuthority> spaces
 ) {
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceList.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceList.java
@@ -1,10 +1,10 @@
 package org.tuna.zoopzoop.backend.domain.space.space.dto.res;
 
-import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceMembershipInfo;
+import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInfo;
 
 import java.util.List;
 
 public record ResBodyForSpaceList(
-        List<SpaceMembershipInfo> spaces
+        List<SpaceInfo> spaces
 ) {
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceListPage.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceListPage.java
@@ -2,20 +2,20 @@ package org.tuna.zoopzoop.backend.domain.space.space.dto.res;
 
 import lombok.Getter;
 import org.springframework.data.domain.Page;
-import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceMembershipInfo;
+import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInfo;
 
 import java.util.List;
 
 @Getter
 public class ResBodyForSpaceListPage {
-    private final List<SpaceMembershipInfo> spaces; // 현재 페이지의 데이터
+    private final List<SpaceInfo> spaces; // 현재 페이지의 데이터
     private final int page;          // 현재 페이지 번호 (0부터 시작)
     private final int size;          // 페이지 크기
     private final long totalElements; // 전체 요소 수
     private final int totalPages;    // 전체 페이지 수
     private final boolean isLast;      // 마지막 페이지 여부
 
-    public ResBodyForSpaceListPage(Page<SpaceMembershipInfo> page) {
+    public ResBodyForSpaceListPage(Page<SpaceInfo> page) {
         this.spaces = page.getContent();
         this.page = page.getNumber();
         this.size = page.getSize();

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceControllerTest.java
@@ -18,6 +18,7 @@ import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
 import org.tuna.zoopzoop.backend.testSupport.ControllerTestSupport;
 
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -439,9 +440,9 @@ class ApiV1SpaceControllerTest extends ControllerTestSupport {
                 .andExpect(jsonPath("$.data.spaces[0].authority").value("ADMIN"))
                 .andExpect(jsonPath("$.data.spaces[0].members").isArray())
                 .andExpect(jsonPath("$.data.spaces[0].members.length()").value(2)) // PENDING 제외 2명
-                .andExpect(jsonPath("$.data.spaces[0].members[0].name").value("spaceControllerTester1"))
+                .andExpect(jsonPath("$.data.spaces[0].members[0].name", startsWith("spaceControllerTester1")))
                 .andExpect(jsonPath("$.data.spaces[0].members[0].authority").value("ADMIN"))
-                .andExpect(jsonPath("$.data.spaces[0].members[1].name").value("spaceControllerTester3"))
+                .andExpect(jsonPath("$.data.spaces[0].members[1].name", startsWith("spaceControllerTester3")))
                 .andExpect(jsonPath("$.data.spaces[0].members[1].authority").value("READ_ONLY"));
 
 
@@ -589,7 +590,7 @@ class ApiV1SpaceControllerTest extends ControllerTestSupport {
     @DisplayName("스페이스 단건 조회 - 실패 : 스페이스 멤버가 아닌 사용자")
     void getSpace_Fail_NotMember() throws Exception {
         // Given
-        Space space = spaceService.findByName("기존 스페이스 1_forSpaceControllerTest");
+        Space space = spaceService.findByName("기존 스페이스 2_forSpaceControllerTest");
         Integer spaceId = space.getId();
         String url = String.format("/api/v1/space/%d", spaceId);
 


### PR DESCRIPTION
## 📢 기능 설명
스페이스 목록 조회 API 보완
- Query String으로 `includeMembers = true` 설정 시 각 스페이스에 속한 멤버들의 정보 목록도 함께 반환

DTO 이름 변경
- `SpaceMemberShipInfo -> SpaceInfo'
- `SpaceMembershipInfoWithoutAuthority` -> `SpaceInfoWithoutAuthority`
- 직관성이 떨어져서 바꿨습니다.

<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] 
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

