### PR TITLE
[Feat/OPS-379] liveblocks 연동

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/controller/ApiV1DashboardController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/controller/ApiV1DashboardController.java
@@ -71,6 +71,6 @@ public class ApiV1DashboardController {
                         "ID: " + dashboardId + " 의 React-flow 데이터를 조회했습니다.",
                         BodyForReactFlow.from(graph)
                 ));
-
     }
+
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/dto/ReqBodyForLiveblocksAuth.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/dto/ReqBodyForLiveblocksAuth.java
@@ -1,0 +1,15 @@
+package org.tuna.zoopzoop.backend.domain.dashboard.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record ReqBodyForLiveblocksAuth(
+        String userId,
+        UserInfo userInfo,
+        Map<String, List<String>>permissions
+) {
+    public record UserInfo(
+            String name,
+            String avatar
+    ) {}
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/dto/ResBodyForAuthToken.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/dto/ResBodyForAuthToken.java
@@ -1,0 +1,5 @@
+package org.tuna.zoopzoop.backend.domain.dashboard.dto;
+
+public record ResBodyForAuthToken(
+        String token
+){ }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/dashboard/service/DashboardService.java
@@ -10,16 +10,24 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.dashboard.dto.BodyForReactFlow;
 import org.tuna.zoopzoop.backend.domain.dashboard.dto.GraphUpdateMessage;
+import org.tuna.zoopzoop.backend.domain.dashboard.dto.ReqBodyForLiveblocksAuth;
 import org.tuna.zoopzoop.backend.domain.dashboard.entity.Dashboard;
 import org.tuna.zoopzoop.backend.domain.dashboard.entity.Edge;
 import org.tuna.zoopzoop.backend.domain.dashboard.entity.Graph;
 import org.tuna.zoopzoop.backend.domain.dashboard.entity.Node;
 import org.tuna.zoopzoop.backend.domain.dashboard.repository.DashboardRepository;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
+import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
+import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
+import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
+import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 
 import java.nio.file.AccessDeniedException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +38,8 @@ public class DashboardService {
     private final ObjectMapper objectMapper;
     private final SignatureService signatureService;
     private final RabbitTemplate rabbitTemplate;
-
+    private final SpaceService spaceService;
+    private final LiveblocksClient liveblocksClient;
 
 
     // =========================== Graph 관련 메서드 ===========================
@@ -134,8 +143,59 @@ public class DashboardService {
         rabbitTemplate.convertAndSend("zoopzoop.exchange", "graph.update.rk", message);
     }
 
+    // =========================== 기타 메서드 ===========================
 
+    /**
+     * 특정 스페이스에 대한 Liveblocks 접속 토큰(JWT)을 발급합니다.
+     * @param spaceId 스페이스 ID
+     * @param member 토큰을 요청하는 멤버
+     * @return 발급된 JWT 문자열
+     * @throws AccessDeniedException 멤버가 해당 스페이스에 속해있지 않거나 권한이 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public String getAuthTokenForSpace(Integer spaceId, Member member) throws AccessDeniedException {
+        Space space = spaceService.findById(spaceId);
 
+        // 해당 스페이스에 멤버가 속해있는지, PENDING 상태는 아닌지 확인
+        Membership membership = membershipService.findByMemberAndSpace(member, space);
+        if (membership.getAuthority().equals(Authority.PENDING)) {
+            throw new AccessDeniedException("스페이스에 가입된 멤버가 아닙니다.");
+        }
+
+        // Liveblocks Room ID 생성
+        String roomId = "space_" + space.getId();
+
+        // Liveblocks에 전달할 사용자 정보 생성
+        String userId = String.valueOf(member.getId());
+        ReqBodyForLiveblocksAuth.UserInfo userInfo = new ReqBodyForLiveblocksAuth.UserInfo(
+                member.getName(),
+                member.getProfileImageUrl()
+        );
+
+        // Liveblocks 권한 설정 (내 서비스의 Authority -> Liveblocks 권한으로 변환)
+        List<String> permissions;
+        switch (membership.getAuthority()) {
+            case ADMIN, READ_WRITE:
+                permissions = List.of("room:write");
+                break;
+            case READ_ONLY:
+                permissions = Collections.emptyList(); // 빈 리스트는 읽기 전용을 의미
+                break;
+            default:
+                // PENDING 등 다른 상태는 위에서 이미 필터링됨
+                throw new AccessDeniedException("유효하지 않은 권한입니다.");
+        }
+
+        // Liveblocks Client에 전달할 요청 객체 생성
+        ReqBodyForLiveblocksAuth authRequest = new ReqBodyForLiveblocksAuth(
+                userId,
+                userInfo,
+                Map.of(roomId, permissions)
+        );
+
+        // LiveblocksClient를 통해 토큰 발급 요청
+        return liveblocksClient.getAuthToken(authRequest);
+    }
 
 
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceController.java
@@ -8,9 +8,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.tuna.zoopzoop.backend.domain.dashboard.dto.ResBodyForAuthToken;
+import org.tuna.zoopzoop.backend.domain.dashboard.service.DashboardService;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.domain.space.membership.dto.etc.SpaceMemberInfo;
 import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
@@ -38,6 +42,7 @@ import java.util.stream.Collectors;
 public class ApiV1SpaceController {
     private final SpaceService spaceService;
     private final MembershipService membershipService;
+    private final DashboardService dashboardService;
 
     @PostMapping
     @Operation(summary = "스페이스 생성")
@@ -206,5 +211,30 @@ public class ApiV1SpaceController {
         );
     }
 
+    /**
+     * Liveblocks 접속을 위한 인증 토큰(JWT) 발급 API
+     * @param spaceId 스페이스 ID
+     * @param userDetails 현재 로그인한 사용자 정보
+     * @return ResponseEntity<RsData<AuthTokenResponse>>
+     */
+    @PostMapping("/dashboard-auth/{spaceId}")
+    @Operation(summary = "Liveblocks 접속 토큰 발급")
+    public ResponseEntity<RsData<ResBodyForAuthToken>> getAuthToken(
+            @PathVariable Integer spaceId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+
+        Member member = userDetails.getMember();
+        String token = dashboardService.getAuthTokenForSpace(spaceId, member);
+
+        ResBodyForAuthToken response = new ResBodyForAuthToken(token);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new RsData<>(
+                        "200",
+                        "Liveblocks 접속 토큰이 발급되었습니다.",
+                        response
+                ));
+    }
 
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/global/clients/liveblocks/LiveblocksClient.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/clients/liveblocks/LiveblocksClient.java
@@ -59,6 +59,25 @@ public class LiveblocksClient {
         }
     }
 
-    // 여기에 나중에 방 삭제, 방 업데이트 등의 메소드를 추가하면 됩니다.
-    // public void deleteRoom(String roomId) { ... }
+    /**
+     * Liveblocks 서버의 방을 삭제합니다.
+     * @param roomId 삭제할 방의 고유 ID
+     */
+    public void deleteRoom(String roomId) {
+        String deleteUrl = LIVEBLOCKS_API_URL + "/" + roomId;
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(secretKey);
+        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+        try {
+            restTemplate.exchange(deleteUrl, HttpMethod.DELETE, requestEntity, Void.class);
+            log.info("Liveblocks room deleted successfully. roomId: {}", roomId);
+        } catch (RestClientException e) {
+            log.error("Error while calling Liveblocks API to delete room. roomId: {}", roomId, e);
+            // 방 삭제 실패가 전체 로직에 큰 영향을 주지 않는다면,
+            // 예외를 던지는 대신 에러 로그만 남기고 넘어갈 수도 있습니다.
+            // 여기서는 일단 예외를 던져서 트랜잭션을 롤백하도록 합니다.
+            throw new RuntimeException("Liveblocks API call failed", e);
+        }
+    }
 }

--- a/src/main/java/org/tuna/zoopzoop/backend/global/clients/liveblocks/LiveblocksClient.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/clients/liveblocks/LiveblocksClient.java
@@ -1,0 +1,64 @@
+package org.tuna.zoopzoop.backend.global.clients.liveblocks;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LiveblocksClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${liveblocks.secret-key}")
+    private String secretKey;
+
+    private static final String LIVEBLOCKS_API_URL = "https://api.liveblocks.io/v2/rooms";
+
+    /**
+     * Liveblocks 서버에 새로운 방을 생성합니다.
+     * @param roomId 생성할 방의 고유 ID (워크스페이스 ID와 동일하게 사용)
+     */
+    public void createRoom(String roomId) {
+        // 1. HTTP 헤더 설정 (Authorization: Bearer sk_...)
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(secretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // 2. Request Body 생성 (비공개 방으로 생성)
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("id", roomId);
+        requestBody.put("defaultAccesses", Collections.emptyList()); // 비공개(private) 방으로 설정
+
+        // 3. HTTP 요청 엔티티 생성
+        HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+        try {
+            // 4. Liveblocks API에 POST 요청 전송
+            ResponseEntity<String> response = restTemplate.postForEntity(LIVEBLOCKS_API_URL, requestEntity, String.class);
+
+            if (response.getStatusCode().is2xxSuccessful()) {
+                log.info("Liveblocks room created successfully. roomId: {}", roomId);
+            } else {
+                log.error("Failed to create Liveblocks room. roomId: {}, status: {}, body: {}",
+                        roomId, response.getStatusCode(), response.getBody());
+            }
+        } catch (RestClientException e) {
+            log.error("Error while calling Liveblocks API to create room. roomId: {}", roomId, e);
+            // 필요하다면 여기서 커스텀 예외를 발생시켜 서비스 레이어에서 처리하도록 할 수 있습니다.
+            throw new RuntimeException("Liveblocks API call failed", e);
+        }
+    }
+
+    // 여기에 나중에 방 삭제, 방 업데이트 등의 메소드를 추가하면 됩니다.
+    // public void deleteRoom(String roomId) { ... }
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/global/config/restTemplate/RestTemplateConfig.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/global/config/restTemplate/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package org.tuna.zoopzoop.backend.global.config.restTemplate;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/dashboard/controller/DashboardControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/dashboard/controller/DashboardControllerTest.java
@@ -2,6 +2,7 @@ package org.tuna.zoopzoop.backend.domain.dashboard.controller;
 
 import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -10,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -25,6 +27,7 @@ import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipServi
 import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
 import org.tuna.zoopzoop.backend.domain.space.space.repository.SpaceRepository;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 import org.tuna.zoopzoop.backend.testSupport.ControllerTestSupport;
 
 import javax.crypto.Mac;
@@ -37,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -56,6 +60,9 @@ class DashboardControllerTest extends ControllerTestSupport {
 
     @Autowired private TransactionTemplate transactionTemplate;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     private Integer unauthorizedDashboardId;
     private Integer authorizedDashboardId;
 
@@ -67,6 +74,9 @@ class DashboardControllerTest extends ControllerTestSupport {
 
     @BeforeAll
     void setUp() {
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
+
         // 1. 유저 생성
         memberService.createMember("tester1_forDashboardControllerTest", "url", "dc1111", Provider.KAKAO);
         memberService.createMember("tester2_forDashboardControllerTest", "url", "dc2222", Provider.KAKAO);

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/dashboard/extraComponent/GraphUpdateConsumerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/dashboard/extraComponent/GraphUpdateConsumerTest.java
@@ -1,9 +1,11 @@
 package org.tuna.zoopzoop.backend.domain.dashboard.extraComponent;
 
 import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.tuna.zoopzoop.backend.domain.dashboard.dto.GraphUpdateMessage;
@@ -12,6 +14,7 @@ import org.tuna.zoopzoop.backend.domain.dashboard.entity.Graph;
 import org.tuna.zoopzoop.backend.domain.dashboard.entity.Node;
 import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 import org.tuna.zoopzoop.backend.testSupport.ControllerTestSupport;
 
 import java.util.Map;
@@ -19,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @SpringBootTest
 @Transactional
@@ -28,6 +32,9 @@ class GraphUpdateConsumerTest extends ControllerTestSupport {
     @Autowired private TransactionTemplate transactionTemplate;
     @Autowired private SpaceService spaceService;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     // 테스트에 사용할 dashboardId (실제 DB에 존재하는 ID)
     private Integer existingDashboardId;
 
@@ -35,6 +42,9 @@ class GraphUpdateConsumerTest extends ControllerTestSupport {
 
     @BeforeAll
     void setUp(){
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
+
         spaceService.createSpace(existingSpaceName, "thumb1");
     }
 

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/archive/controller/SpaceArchiveFolderControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/archive/controller/SpaceArchiveFolderControllerTest.java
@@ -2,12 +2,14 @@ package org.tuna.zoopzoop.backend.domain.space.archive.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.archive.folder.dto.reqBodyForCreateFolder;
@@ -25,6 +27,7 @@ import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 import org.tuna.zoopzoop.backend.global.jpa.entity.BaseEntity;
 
 import java.time.LocalDate;
@@ -32,6 +35,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -55,6 +59,9 @@ class SpaceArchiveFolderControllerTest {
     @Autowired private FolderRepository folderRepository;
     @Autowired private DataSourceRepository dataSourceRepository;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     private static final String OWNER_PK = "sp1111";
     private static final String READER_PK = "sp2222";
 
@@ -67,6 +74,9 @@ class SpaceArchiveFolderControllerTest {
 
     @BeforeAll
     void setUp() {
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
+
         // 사용자 생성
         try { memberService.createMember("spaceOwner", "http://img/owner.png", OWNER_PK, Provider.KAKAO); } catch (Exception ignored) {}
         try { memberService.createMember("spaceReader", "http://img/reader.png", READER_PK, Provider.KAKAO); } catch (Exception ignored) {}

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteControllerTest.java
@@ -4,12 +4,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
@@ -18,8 +20,10 @@ import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 import org.tuna.zoopzoop.backend.testSupport.ControllerTestSupport;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -36,8 +40,14 @@ class ApiV1InviteControllerTest extends ControllerTestSupport {
     @Autowired
     private MembershipService membershipService;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     @BeforeAll
     void setUp() {
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
+
         setUpMember();
         setUpSpace();
         setUpMembership();

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1MembershipControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1MembershipControllerTest.java
@@ -4,12 +4,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
@@ -17,8 +19,10 @@ import org.tuna.zoopzoop.backend.domain.member.service.MemberService;
 import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 import org.tuna.zoopzoop.backend.testSupport.ControllerTestSupport;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,8 +39,14 @@ class ApiV1MembershipControllerTest extends ControllerTestSupport {
     @Autowired
     private MembershipService membershipService;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     @BeforeAll
     void setUp() {
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
+
         setUpMember();
         setUpSpace();
         setUpMembership();

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/service/MembershipServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/service/MembershipServiceTest.java
@@ -2,10 +2,12 @@ package org.tuna.zoopzoop.backend.domain.space.membership.service;
 
 import jakarta.persistence.NoResultException;
 import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
@@ -15,12 +17,14 @@ import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
 import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.repository.MembershipRepository;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -38,8 +42,14 @@ class MembershipServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     @BeforeAll
     void setUp() {
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
+
         membershipRepository.deleteAll();
         setUpMember();
         setUpSpace();

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/controller/ApiV1SpaceControllerTest.java
@@ -1,12 +1,14 @@
 package org.tuna.zoopzoop.backend.domain.space.space.controller;
 
 import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.member.enums.Provider;
@@ -15,10 +17,12 @@ import org.tuna.zoopzoop.backend.domain.space.membership.enums.Authority;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
 import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
 import org.tuna.zoopzoop.backend.domain.space.space.service.SpaceService;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 import org.tuna.zoopzoop.backend.testSupport.ControllerTestSupport;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,8 +40,14 @@ class ApiV1SpaceControllerTest extends ControllerTestSupport {
     @Autowired
     private MembershipService membershipService;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     @BeforeAll
     void setUp() {
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
+
         setUpMember();
         setUpSpace();
         setUpMembership();

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/service/SpaceServiceTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/space/service/SpaceServiceTest.java
@@ -5,14 +5,18 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import org.tuna.zoopzoop.backend.domain.space.space.entity.Space;
 import org.tuna.zoopzoop.backend.domain.space.space.exception.DuplicateSpaceNameException;
+import org.tuna.zoopzoop.backend.global.clients.liveblocks.LiveblocksClient;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -21,8 +25,12 @@ class SpaceServiceTest {
     @Autowired
     private SpaceService spaceService;
 
+    @MockitoBean
+    private LiveblocksClient liveblocksClient;
+
     @BeforeEach
     void setUp() {
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
         spaceService.createSpace("기존 스페이스 1_forSpaceServiceTest");
         spaceService.createSpace("기존 스페이스 2_forSpaceServiceTest");
     }
@@ -33,6 +41,9 @@ class SpaceServiceTest {
     void createSpace_Success() {
         // Given
         String spaceName = "테스트 스페이스";
+
+        // liveblocksClient.createRoom() 메서드가 호출될 때 실제로 아무 작업도 하지 않도록 설정
+        Mockito.doNothing().when(liveblocksClient).createRoom(anyString());
 
         // When
         var createdSpace = spaceService.createSpace(spaceName);
@@ -73,6 +84,9 @@ class SpaceServiceTest {
         Space space = spaceService.findByName("기존 스페이스 1_forSpaceServiceTest");
         Integer spaceId = space.getId();
         String spaceName = space.getName();
+
+        // Mockito 설정: deleteRoom 메소드가 어떤 문자열로 호출되더라도 아무런 동작을 하지 않도록 설정
+        Mockito.doNothing().when(liveblocksClient).deleteRoom(anyString());
 
         // When
         String deletedSpaceName = spaceService.deleteSpace(spaceId);


### PR DESCRIPTION
## 📢 기능 설명
Liveblocks 연동
- 스페이스 생성/삭제 시 liveblocks의 연동된 room이 생성/삭제 되도록 설정
- room에 대한 access token을 반환하는 엔드포인트 생성
- 기존에 스페이스 생성/삭제를 하는 테스트 케이스에 대해 Mock 객체 도입

<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

