### PR TITLE
Hotfix/스페이스초대목록 반환 시 invite id 포함

### DIFF
--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteController.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import org.tuna.zoopzoop.backend.domain.member.entity.Member;
 import org.tuna.zoopzoop.backend.domain.space.membership.entity.Membership;
 import org.tuna.zoopzoop.backend.domain.space.membership.service.MembershipService;
+import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInvitationInfo;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceInviteList;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.res.ResBodyForSpaceSave;
 import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInfoWithoutAuthority;
@@ -81,11 +82,12 @@ public class ApiV1InviteController {
 
         // 멤버십(초대) 목록 조회
         List<Membership> invitations = membershipService.findByMember(member, "PENDING");
-        List<SpaceInfoWithoutAuthority> invitationInfos = invitations.stream()
-                .map(membership -> new SpaceInfoWithoutAuthority(
+        List<SpaceInvitationInfo> invitationInfo = invitations.stream()
+                .map(membership -> new SpaceInvitationInfo(
                         membership.getSpace().getId(),
                         membership.getSpace().getName(),
-                        membership.getSpace().getThumbnailUrl()
+                        membership.getSpace().getThumbnailUrl(),
+                        membership.getId()
                 ))
                 .toList();
 
@@ -93,7 +95,7 @@ public class ApiV1InviteController {
                 "200",
                 "사용자에게 온 스페이스 초대 목록을 조회했습니다.",
                 new ResBodyForSpaceInviteList(
-                        invitationInfos
+                        invitationInfo
                 )
         );
     }

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInvitationInfo.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/etc/SpaceInvitationInfo.java
@@ -1,0 +1,9 @@
+package org.tuna.zoopzoop.backend.domain.space.space.dto.etc;
+
+public record SpaceInvitationInfo(
+        Integer spaceId,
+        String spaceName,
+        String spaceThumbnailUrl,
+        Integer inviteId
+) {
+}

--- a/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceInviteList.java
+++ b/src/main/java/org/tuna/zoopzoop/backend/domain/space/space/dto/res/ResBodyForSpaceInviteList.java
@@ -1,10 +1,11 @@
 package org.tuna.zoopzoop.backend.domain.space.space.dto.res;
 
 import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInfoWithoutAuthority;
+import org.tuna.zoopzoop.backend.domain.space.space.dto.etc.SpaceInvitationInfo;
 
 import java.util.List;
 
 public record ResBodyForSpaceInviteList(
-        List<SpaceInfoWithoutAuthority> spaces
+        List<SpaceInvitationInfo> spaces
 ) {
 }

--- a/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteControllerTest.java
+++ b/src/test/java/org/tuna/zoopzoop/backend/domain/space/membership/controller/ApiV1InviteControllerTest.java
@@ -278,12 +278,14 @@ class ApiV1InviteControllerTest extends ControllerTestSupport {
         resultActions
                 .andExpect(jsonPath("$.data.spaces").isArray())
                 .andExpect(jsonPath("$.data.spaces.length()").value(2))
-                .andExpect(jsonPath("$.data.spaces[0].id").value(space1.getId()))
-                .andExpect(jsonPath("$.data.spaces[0].name").value(space1.getName()))
-                .andExpect(jsonPath("$.data.spaces[0].thumbnailUrl").value(space1.getThumbnailUrl()))
-                .andExpect(jsonPath("$.data.spaces[1].id").value(space2.getId()))
-                .andExpect(jsonPath("$.data.spaces[1].name").value(space2.getName()))
-                .andExpect(jsonPath("$.data.spaces[1].thumbnailUrl").value(space2.getThumbnailUrl()));
+                .andExpect(jsonPath("$.data.spaces[0].spaceId").value(space1.getId()))
+                .andExpect(jsonPath("$.data.spaces[0].spaceName").value(space1.getName()))
+                .andExpect(jsonPath("$.data.spaces[0].spaceThumbnailUrl").value(space1.getThumbnailUrl()))
+                .andExpect(jsonPath("$.data.spaces[0].inviteId").isNumber())
+                .andExpect(jsonPath("$.data.spaces[1].spaceId").value(space2.getId()))
+                .andExpect(jsonPath("$.data.spaces[1].spaceName").value(space2.getName()))
+                .andExpect(jsonPath("$.data.spaces[1].spaceThumbnailUrl").value(space2.getThumbnailUrl()))
+                .andExpect(jsonPath("$.data.spaces[1].inviteId").isNumber());
     }
 
 


### PR DESCRIPTION
## 📢 기능 설명
- 스페이스 초대 목록 반환 시 invite Id 를 포함하도록 dto 변경
<br>


## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?

